### PR TITLE
refactor: modernize python samples and integrate ruff linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/__pycache__
+.pytest_cache
+.ruff_cache
+uv.lock
+.venv

--- a/rest/python/client/flower_shop/pyproject.toml
+++ b/rest/python/client/flower_shop/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "httpx>=0.26.0",
+    "ruff>=0.14.11",
 ]
 
 [build-system]
@@ -27,3 +28,23 @@ packages = ["."]
 [tool.uv.sources]
 # The relative path is stored here
 ucp-sdk = { path = "../../../../../sdk/python/", editable = true }
+
+[tool.ruff]
+line-length = 80
+indent-width = 2
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B", "C4", "SIM", "N", "UP", "D", "PTH", "T20"]
+ignore = ["D203", "D213"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+force-sort-within-sections = true
+case-sensitive = true

--- a/rest/python/server/__init__.py
+++ b/rest/python/server/__init__.py
@@ -1,0 +1,1 @@
+"""UCP Merchant Server sample implementation."""

--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -23,7 +23,8 @@ including:
 """
 
 import re
-from typing import AsyncGenerator, Optional
+from collections.abc import AsyncGenerator
+from typing import Annotated
 
 import config
 import db
@@ -40,30 +41,30 @@ from sqlalchemy.ext.asyncio import AsyncSession
 class CommonHeaders(BaseModel):
   """Common headers used in UCP requests."""
 
-  x_api_key: Optional[str] = None
+  x_api_key: str | None = None
   ucp_agent: str
   request_signature: str
   request_id: str
 
 
 async def common_headers(
-    x_api_key: Optional[str] = Header(None),
-    ucp_agent: str = Header(...),
-    request_signature: str = Header(...),
-    request_id: str = Header(...),
+  x_api_key: str | None = Header(None),
+  ucp_agent: str = Header(...),
+  request_signature: str = Header(...),
+  request_id: str = Header(...),
 ) -> CommonHeaders:
-  """Extracts and validates common headers."""
+  """Extract and validate common headers."""
   await validate_ucp_headers(ucp_agent)
   return CommonHeaders(
-      x_api_key=x_api_key,
-      ucp_agent=ucp_agent,
-      request_signature=request_signature,
-      request_id=request_id,
+    x_api_key=x_api_key,
+    ucp_agent=ucp_agent,
+    request_signature=request_signature,
+    request_id=request_id,
   )
 
 
 async def validate_ucp_headers(ucp_agent: str):
-  """Validates UCP headers and version negotiation."""
+  """Validate UCP headers and version negotiation."""
   server_version = config.get_server_version()
   agent_version = server_version  # Default to server version if not specified
 
@@ -72,7 +73,7 @@ async def validate_ucp_headers(ucp_agent: str):
   # allowing for whitespace.
   # Matches: version="1.2.3" or version=1.2.3
   match = re.search(
-      r"(?:^|;)\s*version=(?:\"([^\"]+)\"|([^;]+))", ucp_agent, re.IGNORECASE
+    r"(?:^|;)\s*version=(?:\"([^\"]+)\"|([^;]+))", ucp_agent, re.IGNORECASE
   )
   if match:
     # Group 1 is quoted value, Group 2 is unquoted value
@@ -81,32 +82,34 @@ async def validate_ucp_headers(ucp_agent: str):
 
   if agent_version > server_version:
     raise HTTPException(
-        status_code=400,
-        detail={
-            "status": "error",
-            "errors": [{
-                "code": "VERSION_UNSUPPORTED",
-                "message": (
-                    f"Version {agent_version} is not supported. This merchant"
-                    f" implements version {server_version}."
-                ),
-                "severity": "critical",
-            }],
-        },
+      status_code=400,
+      detail={
+        "status": "error",
+        "errors": [
+          {
+            "code": "VERSION_UNSUPPORTED",
+            "message": (
+              f"Version {agent_version} is not supported. This merchant"
+              f" implements version {server_version}."
+            ),
+            "severity": "critical",
+          }
+        ],
+      },
     )
 
 
 async def idempotency_header(
-    idempotency_key: str = Header(...),
+  idempotency_key: str = Header(...),
 ) -> str:
-  """Extracts the Idempotency-Key header."""
+  """Extract the Idempotency-Key header."""
   return idempotency_key
 
 
 async def verify_signature(
-    request_signature: str = Header(..., alias="Request-Signature"),
+  request_signature: str = Header(..., alias="Request-Signature"),
 ) -> None:
-  """Verifies the request signature.
+  """Verify the request signature.
 
   Note: This is a placeholder implementation that bypasses validation if the
   signature is "test". A real implementation would verify the HMAC-SHA256
@@ -114,6 +117,7 @@ async def verify_signature(
 
   Args:
     request_signature: The signature header from the platform.
+
   """
   # In tests, we might want to bypass validation if signature is "test"
   if request_signature == "test":
@@ -124,13 +128,13 @@ async def verify_signature(
 
 
 async def verify_simulation_secret(
-    simulation_secret: Optional[str] = Header(None, alias="Simulation-Secret"),
+  simulation_secret: str | None = Header(None, alias="Simulation-Secret"),
 ) -> None:
-  """Verifies the secret for simulation endpoints."""
+  """Verify the secret for simulation endpoints."""
   expected_secret = config.FLAGS.simulation_secret
   if not expected_secret:
     raise HTTPException(
-        status_code=500, detail="Simulation secret not configured"
+      status_code=500, detail="Simulation secret not configured"
     )
 
   if not simulation_secret or simulation_secret != expected_secret:
@@ -155,15 +159,17 @@ async def get_transactions_db() -> AsyncGenerator[AsyncSession, None]:
 
 
 def get_checkout_service(
-    request: Request,
-    fulfillment_service: FulfillmentService = Depends(get_fulfillment_service),
-    products_session: AsyncSession = Depends(get_products_db),
-    transactions_session: AsyncSession = Depends(get_transactions_db),
+  request: Request,
+  fulfillment_service: Annotated[
+    FulfillmentService, Depends(get_fulfillment_service)
+  ],
+  products_session: Annotated[AsyncSession, Depends(get_products_db)],
+  transactions_session: Annotated[AsyncSession, Depends(get_transactions_db)],
 ) -> CheckoutService:
   """Dependency provider for CheckoutService."""
   return CheckoutService(
-      fulfillment_service,
-      products_session,
-      transactions_session,
-      str(request.base_url),
+    fulfillment_service,
+    products_session,
+    transactions_session,
+    str(request.base_url),
   )

--- a/rest/python/server/dump_inventory.py
+++ b/rest/python/server/dump_inventory.py
@@ -37,15 +37,15 @@ flags.DEFINE_string("transactions_db_path", None, "Path to transactions DB")
 
 
 async def dump_inventory():
-  """Queries the database and prints current inventory levels."""
+  """Query the database and print current inventory levels."""
   if not FLAGS.transactions_db_path:
-    print("Error: --transactions_db_path is required.")
+    sys.stderr.write("Error: --transactions_db_path is required.\n")
     sys.exit(1)
 
   db_url = f"sqlite+aiosqlite:///{FLAGS.transactions_db_path}"
   engine = create_async_engine(db_url, echo=False)
   session_factory = sessionmaker(
-      engine, expire_on_commit=False, class_=AsyncSession
+    engine, expire_on_commit=False, class_=AsyncSession
   )
 
   async with session_factory() as session:
@@ -59,7 +59,7 @@ async def dump_inventory():
 
 
 def main(argv):
-  """Main entry point for the inventory dump script."""
+  """Run the inventory dump script."""
   del argv
   asyncio.run(dump_inventory())
 

--- a/rest/python/server/dump_log.py
+++ b/rest/python/server/dump_log.py
@@ -39,55 +39,55 @@ from sqlalchemy.orm import sessionmaker
 FLAGS = flags.FLAGS
 flags.DEFINE_string("transactions_db_path", None, "Path to transactions DB")
 flags.DEFINE_bool(
-    "show_transaction", False, "Show correlated transaction details"
+  "show_transaction", False, "Show correlated transaction details"
 )
 
 
 async def dump_logs():
-  """Queries the database and prints request logs."""
+  """Query the database and print request logs."""
   if not FLAGS.transactions_db_path:
-    print("Error: --transactions_db_path is required.")
+    sys.stderr.write("Error: --transactions_db_path is required.\n")
     sys.exit(1)
 
   db_url = f"sqlite+aiosqlite:///{FLAGS.transactions_db_path}"
   engine = create_async_engine(db_url, echo=False)
   session_factory = sessionmaker(
-      engine, expire_on_commit=False, class_=AsyncSession
+    engine, expire_on_commit=False, class_=AsyncSession
   )
 
   async with session_factory() as session:
-    print("=== REQUEST LOGS ===")
+    print("=== REQUEST LOGS ===")  # noqa: T201
     result = await session.execute(select(RequestLog).order_by(RequestLog.id))
     logs = result.scalars().all()
 
     if not logs:
-      print("No request logs found.")
+      print("No request logs found.")  # noqa: T201
       return
 
     for log in logs:
-      print(f"[{log.timestamp}] {log.method} {log.url}")
+      print(f"[{log.timestamp}] {log.method} {log.url}")  # noqa: T201
       if log.checkout_id:
-        print(f"  Checkout ID: {log.checkout_id}")
+        print(f"  Checkout ID: {log.checkout_id}")  # noqa: T201
 
         if FLAGS.show_transaction:
           transaction_result = await session.get(
-              CheckoutSession, log.checkout_id
+            CheckoutSession, log.checkout_id
           )
           if transaction_result:
-            print(f"  Transaction Status: {transaction_result.status}")
+            print(f"  Transaction Status: {transaction_result.status}")  # noqa: T201
 
       if log.payload:
         try:
           # Pretty print JSON if possible
           payload_obj = json.loads(log.payload)
-          print(f"  Payload: {json.dumps(payload_obj, indent=2)}")
+          print(f"  Payload: {json.dumps(payload_obj, indent=2)}")  # noqa: T201
         except (json.JSONDecodeError, TypeError):
-          print(f"  Payload: {log.payload}")
-      print("-" * 40)
+          print(f"  Payload: {log.payload}")  # noqa: T201
+      print("-" * 40)  # noqa: T201
 
 
 def main(argv):
-  """Main entry point for the log dump script."""
+  """Run the log dump script."""
   del argv
   asyncio.run(dump_logs())
 

--- a/rest/python/server/dump_transactions.py
+++ b/rest/python/server/dump_transactions.py
@@ -38,15 +38,15 @@ flags.DEFINE_string("transactions_db_path", None, "Path to transactions DB")
 
 
 async def dump_transactions():
-  """Queries the database and prints all checkout transactions."""
+  """Query the database and print all checkout transactions."""
   if not FLAGS.transactions_db_path:
-    print("Error: --transactions_db_path is required.")
+    sys.stderr.write("Error: --transactions_db_path is required.\n")
     sys.exit(1)
 
   db_url = f"sqlite+aiosqlite:///{FLAGS.transactions_db_path}"
   engine = create_async_engine(db_url, echo=False)
   session_factory = sessionmaker(
-      engine, expire_on_commit=False, class_=AsyncSession
+    engine, expire_on_commit=False, class_=AsyncSession
   )
 
   async with session_factory() as session:
@@ -54,11 +54,11 @@ async def dump_transactions():
     checkouts = result.scalars().all()
 
     if not checkouts:
-      print("No transactions found.")
+      print("No transactions found.")  # noqa: T201
       return
 
     for checkout in checkouts:
-      print(f"Transaction: {checkout.id} [{checkout.status}]")
+      print(f"Transaction: {checkout.id} [{checkout.status}]")  # noqa: T201
       try:
         if isinstance(checkout.data, str):
           data = json.loads(checkout.data)
@@ -73,19 +73,19 @@ async def dump_transactions():
             qty = line.get("quantity", 0)
             price = item.get("price", 0) / 100.0
             total = line.get("total", 0) / 100.0
-            print(
-                f"  - {title} (ID: {item_id}) x{qty} @ ${price:.2f} ="
-                f" ${total:.2f}"
+            print(  # noqa: T201
+              f"  - {title} (ID: {item_id}) x{qty} @ ${price:.2f} ="
+              f" ${total:.2f}"
             )
         else:
-          print("  (No items)")
+          print("  (No items)")  # noqa: T201
       except json.JSONDecodeError:
-        print("  (Error parsing transaction data)")
-      print("-" * 60)
+        print("  (Error parsing transaction data)")  # noqa: T201
+      print("-" * 60)  # noqa: T201
 
 
 def main(argv):
-  """Main entry point for the transaction dump script."""
+  """Run the transaction dump script."""
   del argv
   asyncio.run(dump_transactions())
 

--- a/rest/python/server/enums.py
+++ b/rest/python/server/enums.py
@@ -22,6 +22,8 @@ import enum
 
 
 class CheckoutStatus(str, enum.Enum):
+  """Possible states for a checkout session."""
+
   IN_PROGRESS = "incomplete"
   REQUIRES_ESCALATION = "requires_escalation"
   READY_FOR_COMPLETE = "ready_for_complete"
@@ -31,4 +33,6 @@ class CheckoutStatus(str, enum.Enum):
 
 
 class OrderStatus(str, enum.Enum):
+  """Possible states for an order."""
+
   PROCESSING = "processing"

--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -19,8 +19,9 @@ class UcpError(Exception):
   """Base class for all UCP exceptions."""
 
   def __init__(
-      self, message: str, code: str = "INTERNAL_ERROR", status_code: int = 500
+    self, message: str, code: str = "INTERNAL_ERROR", status_code: int = 500
   ):
+    """Initialize UcpError."""
     self.message = message
     self.code = code
     self.status_code = status_code
@@ -31,6 +32,7 @@ class ResourceNotFoundError(UcpError):
   """Raised when a requested resource is not found."""
 
   def __init__(self, message: str):
+    """Initialize ResourceNotFoundError."""
     super().__init__(message, code="RESOURCE_NOT_FOUND", status_code=404)
 
 
@@ -38,6 +40,7 @@ class IdempotencyConflictError(UcpError):
   """Raised when an idempotency key is reused with different parameters."""
 
   def __init__(self, message: str):
+    """Initialize IdempotencyConflictError."""
     super().__init__(message, code="IDEMPOTENCY_CONFLICT", status_code=409)
 
 
@@ -45,6 +48,7 @@ class CheckoutNotModifiableError(UcpError):
   """Raised when attempting to modify a checkout in a terminal state."""
 
   def __init__(self, message: str):
+    """Initialize CheckoutNotModifiableError."""
     super().__init__(message, code="CHECKOUT_NOT_MODIFIABLE", status_code=409)
 
 
@@ -52,6 +56,7 @@ class OutOfStockError(UcpError):
   """Raised when there is insufficient inventory for an item."""
 
   def __init__(self, message: str, status_code: int = 400):
+    """Initialize OutOfStockError."""
     super().__init__(message, code="OUT_OF_STOCK", status_code=status_code)
 
 
@@ -59,8 +64,9 @@ class PaymentFailedError(UcpError):
   """Raised when payment processing fails."""
 
   def __init__(
-      self, message: str, code: str = "PAYMENT_FAILED", status_code: int = 402
+    self, message: str, code: str = "PAYMENT_FAILED", status_code: int = 402
   ):
+    """Initialize PaymentFailedError."""
     super().__init__(message, code=code, status_code=status_code)
 
 
@@ -68,4 +74,5 @@ class InvalidRequestError(UcpError):
   """Raised when the request is invalid (e.g. missing fields)."""
 
   def __init__(self, message: str):
+    """Initialize InvalidRequestError."""
     super().__init__(message, code="INVALID_REQUEST", status_code=400)

--- a/rest/python/server/generated_routes/__init__.py
+++ b/rest/python/server/generated_routes/__init__.py
@@ -1,0 +1,1 @@
+"""Generated routes package."""

--- a/rest/python/server/generated_routes/ucp_routes.py
+++ b/rest/python/server/generated_routes/ucp_routes.py
@@ -1,8 +1,7 @@
-# generated file
-# pylint: disable=all
+"""Generated routes for UCP server."""
 
-from typing import Any, Dict, Optional
-from fastapi import APIRouter, Body, Depends, Header
+from typing import Annotated
+from fastapi import APIRouter, Body, Header
 import ucp_sdk.models.schemas.shopping.checkout_create_req
 import ucp_sdk.models.schemas.shopping.checkout_resp
 import ucp_sdk.models.schemas.shopping.checkout_update_req
@@ -14,149 +13,151 @@ router = APIRouter()
 
 
 @router.post(
-    "/checkout-sessions",
-    response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
-    status_code=201,
-    operation_id="create_checkout",
-    summary="Create Checkout",
+  "/checkout-sessions",
+  response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
+  status_code=201,
+  operation_id="create_checkout",
+  summary="Create Checkout",
 )
 async def create_checkout(
-    authorization: str = Header(None, alias="Authorization"),
-    x_api_key: str = Header(None, alias="X-API-Key"),
-    request_signature: str = Header(..., alias="Request-Signature"),
-    idempotency_key: str = Header(..., alias="Idempotency-Key"),
-    request_id: str = Header(..., alias="Request-Id"),
-    user_agent: str = Header(None, alias="User-Agent"),
-    content_type: str = Header(None, alias="Content-Type"),
-    accept: str = Header(None, alias="Accept"),
-    accept_language: str = Header(None, alias="Accept-Language"),
-    accept_encoding: str = Header(None, alias="Accept-Encoding"),
-    body: ucp_sdk.models.schemas.shopping.checkout_create_req.CheckoutCreateRequest = Body(
-        ...
-    ),
+  body: Annotated[
+    ucp_sdk.models.schemas.shopping.checkout_create_req.CheckoutCreateRequest,
+    Body(...),
+  ],
+  authorization: str = Header(None, alias="Authorization"),
+  x_api_key: str = Header(None, alias="X-API-Key"),
+  request_signature: str = Header(..., alias="Request-Signature"),
+  idempotency_key: str = Header(..., alias="Idempotency-Key"),
+  request_id: str = Header(..., alias="Request-Id"),
+  user_agent: str = Header(None, alias="User-Agent"),
+  content_type: str = Header(None, alias="Content-Type"),
+  accept: str = Header(None, alias="Accept"),
+  accept_language: str = Header(None, alias="Accept-Language"),
+  accept_encoding: str = Header(None, alias="Accept-Encoding"),
 ):
-  """Create Checkout"""
+  """Create Checkout."""
   # TODO: Implement logic
   return {}
 
 
 @router.get(
-    "/checkout-sessions/{id}",
-    response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
-    status_code=200,
-    operation_id="get_checkout",
-    summary="Get Checkout",
+  "/checkout-sessions/{id}",
+  response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
+  status_code=200,
+  operation_id="get_checkout",
+  summary="Get Checkout",
 )
 async def get_checkout(
-    id: str,
-    authorization: str = Header(None, alias="Authorization"),
-    x_api_key: str = Header(None, alias="X-API-Key"),
-    request_signature: str = Header(..., alias="Request-Signature"),
-    idempotency_key: str = Header(..., alias="Idempotency-Key"),
-    request_id: str = Header(..., alias="Request-Id"),
-    user_agent: str = Header(None, alias="User-Agent"),
-    content_type: str = Header(None, alias="Content-Type"),
-    accept: str = Header(None, alias="Accept"),
-    accept_language: str = Header(None, alias="Accept-Language"),
-    accept_encoding: str = Header(None, alias="Accept-Encoding"),
+  id: str,
+  authorization: str = Header(None, alias="Authorization"),
+  x_api_key: str = Header(None, alias="X-API-Key"),
+  request_signature: str = Header(..., alias="Request-Signature"),
+  idempotency_key: str = Header(..., alias="Idempotency-Key"),
+  request_id: str = Header(..., alias="Request-Id"),
+  user_agent: str = Header(None, alias="User-Agent"),
+  content_type: str = Header(None, alias="Content-Type"),
+  accept: str = Header(None, alias="Accept"),
+  accept_language: str = Header(None, alias="Accept-Language"),
+  accept_encoding: str = Header(None, alias="Accept-Encoding"),
 ):
-  """Get Checkout"""
+  """Get Checkout."""
   # TODO: Implement logic
   return {}
 
 
 @router.put(
-    "/checkout-sessions/{id}",
-    response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
-    status_code=200,
-    operation_id="update_checkout",
-    summary="Update Checkout",
+  "/checkout-sessions/{id}",
+  response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
+  status_code=200,
+  operation_id="update_checkout",
+  summary="Update Checkout",
 )
 async def update_checkout(
-    id: str,
-    authorization: str = Header(None, alias="Authorization"),
-    x_api_key: str = Header(None, alias="X-API-Key"),
-    request_signature: str = Header(..., alias="Request-Signature"),
-    idempotency_key: str = Header(..., alias="Idempotency-Key"),
-    request_id: str = Header(..., alias="Request-Id"),
-    user_agent: str = Header(None, alias="User-Agent"),
-    content_type: str = Header(None, alias="Content-Type"),
-    accept: str = Header(None, alias="Accept"),
-    accept_language: str = Header(None, alias="Accept-Language"),
-    accept_encoding: str = Header(None, alias="Accept-Encoding"),
-    body: ucp_sdk.models.schemas.shopping.checkout_update_req.CheckoutUpdateRequest = Body(
-        ...
-    ),
+  id: str,
+  body: Annotated[
+    ucp_sdk.models.schemas.shopping.checkout_update_req.CheckoutUpdateRequest,
+    Body(...),
+  ],
+  authorization: str = Header(None, alias="Authorization"),
+  x_api_key: str = Header(None, alias="X-API-Key"),
+  request_signature: str = Header(..., alias="Request-Signature"),
+  idempotency_key: str = Header(..., alias="Idempotency-Key"),
+  request_id: str = Header(..., alias="Request-Id"),
+  user_agent: str = Header(None, alias="User-Agent"),
+  content_type: str = Header(None, alias="Content-Type"),
+  accept: str = Header(None, alias="Accept"),
+  accept_language: str = Header(None, alias="Accept-Language"),
+  accept_encoding: str = Header(None, alias="Accept-Encoding"),
 ):
-  """Update Checkout"""
+  """Update Checkout."""
   # TODO: Implement logic
   return {}
 
 
 @router.post(
-    "/checkout-sessions/{id}/complete",
-    response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
-    status_code=200,
-    operation_id="complete_checkout",
-    summary="Complete Checkout",
+  "/checkout-sessions/{id}/complete",
+  response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
+  status_code=200,
+  operation_id="complete_checkout",
+  summary="Complete Checkout",
 )
 async def complete_checkout(
-    id: str,
-    authorization: str = Header(None, alias="Authorization"),
-    x_api_key: str = Header(None, alias="X-API-Key"),
-    request_signature: str = Header(..., alias="Request-Signature"),
-    idempotency_key: str = Header(..., alias="Idempotency-Key"),
-    request_id: str = Header(..., alias="Request-Id"),
-    user_agent: str = Header(None, alias="User-Agent"),
-    content_type: str = Header(None, alias="Content-Type"),
-    accept: str = Header(None, alias="Accept"),
-    accept_language: str = Header(None, alias="Accept-Language"),
-    accept_encoding: str = Header(None, alias="Accept-Encoding"),
-    body: dict = Body(...),
+  id: str,
+  body: Annotated[dict, Body(...)],
+  authorization: str = Header(None, alias="Authorization"),
+  x_api_key: str = Header(None, alias="X-API-Key"),
+  request_signature: str = Header(..., alias="Request-Signature"),
+  idempotency_key: str = Header(..., alias="Idempotency-Key"),
+  request_id: str = Header(..., alias="Request-Id"),
+  user_agent: str = Header(None, alias="User-Agent"),
+  content_type: str = Header(None, alias="Content-Type"),
+  accept: str = Header(None, alias="Accept"),
+  accept_language: str = Header(None, alias="Accept-Language"),
+  accept_encoding: str = Header(None, alias="Accept-Encoding"),
 ):
-  """Complete Checkout"""
+  """Complete Checkout."""
   # TODO: Implement logic
   return {}
 
 
 @router.post(
-    "/checkout-sessions/{id}/cancel",
-    response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
-    status_code=200,
-    operation_id="cancel_checkout",
-    summary="Cancel Checkout",
+  "/checkout-sessions/{id}/cancel",
+  response_model=ucp_sdk.models.schemas.shopping.checkout_resp.CheckoutResponse,
+  status_code=200,
+  operation_id="cancel_checkout",
+  summary="Cancel Checkout",
 )
 async def cancel_checkout(
-    id: str,
-    authorization: str = Header(None, alias="Authorization"),
-    x_api_key: str = Header(None, alias="X-API-Key"),
-    request_signature: str = Header(..., alias="Request-Signature"),
-    idempotency_key: str = Header(..., alias="Idempotency-Key"),
-    request_id: str = Header(..., alias="Request-Id"),
-    user_agent: str = Header(None, alias="User-Agent"),
-    content_type: str = Header(None, alias="Content-Type"),
-    accept: str = Header(None, alias="Accept"),
-    accept_language: str = Header(None, alias="Accept-Language"),
-    accept_encoding: str = Header(None, alias="Accept-Encoding"),
+  id: str,
+  authorization: str = Header(None, alias="Authorization"),
+  x_api_key: str = Header(None, alias="X-API-Key"),
+  request_signature: str = Header(..., alias="Request-Signature"),
+  idempotency_key: str = Header(..., alias="Idempotency-Key"),
+  request_id: str = Header(..., alias="Request-Id"),
+  user_agent: str = Header(None, alias="User-Agent"),
+  content_type: str = Header(None, alias="Content-Type"),
+  accept: str = Header(None, alias="Accept"),
+  accept_language: str = Header(None, alias="Accept-Language"),
+  accept_encoding: str = Header(None, alias="Accept-Encoding"),
 ):
-  """Cancel Checkout"""
+  """Cancel Checkout."""
   # TODO: Implement logic
   return {}
 
 
 @router.post(
-    "/webhooks/partners/{partner_id}/events/order",
-    response_model=dict,
-    status_code=200,
-    operation_id="order_event_webhook",
-    summary="Order Event Webhook",
+  "/webhooks/partners/{partner_id}/events/order",
+  response_model=dict,
+  status_code=200,
+  operation_id="order_event_webhook",
+  summary="Order Event Webhook",
 )
 async def order_event_webhook(
-    partner_id: str,
-    request_signature: str = Header(..., alias="Request-Signature"),
-    x_api_key: str = Header(None, alias="X-API-Key"),
-    body: ucp_sdk.models.schemas.shopping.order.Order = Body(...),
+  partner_id: str,
+  body: Annotated[ucp_sdk.models.schemas.shopping.order.Order, Body(...)],
+  request_signature: str = Header(..., alias="Request-Signature"),
+  x_api_key: str = Header(None, alias="X-API-Key"),
 ):
-  """Order Event Webhook"""
+  """Order Event Webhook."""
   # TODO: Implement logic
   return {}

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -15,10 +15,10 @@
 """Integration tests for the UCP SDK Server."""
 
 import asyncio
-import os
+from pathlib import Path
 import shutil
 import tempfile
-from typing import AsyncGenerator, Dict, Optional
+from collections.abc import AsyncGenerator
 import uuid
 
 from absl import flags
@@ -33,11 +33,19 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import delete
 from ucp_sdk.models.schemas.shopping import checkout_create_req
 from ucp_sdk.models.schemas.shopping import payment_create_req
-from ucp_sdk.models.schemas.shopping.ap2_mandate import CheckoutResponseWithAp2 as Ap2Checkout
-from ucp_sdk.models.schemas.shopping.buyer_consent_resp import Checkout as BuyerConsentCheckoutResp
-from ucp_sdk.models.schemas.shopping.discount_resp import Checkout as DiscountCheckoutResp
+from ucp_sdk.models.schemas.shopping.ap2_mandate import (
+  CheckoutResponseWithAp2 as Ap2Checkout,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent_resp import (
+  Checkout as BuyerConsentCheckoutResp,
+)
+from ucp_sdk.models.schemas.shopping.discount_resp import (
+  Checkout as DiscountCheckoutResp,
+)
 from ucp_sdk.models.schemas.shopping.fulfillment_create_req import Fulfillment
-from ucp_sdk.models.schemas.shopping.fulfillment_resp import Checkout as FulfillmentCheckout
+from ucp_sdk.models.schemas.shopping.fulfillment_resp import (
+  Checkout as FulfillmentCheckout,
+)
 from ucp_sdk.models.schemas.shopping.order import PlatformConfig
 from ucp_sdk.models.schemas.shopping.payment_data import PaymentData
 from ucp_sdk.models.schemas.shopping.types import card_payment_instrument
@@ -56,38 +64,38 @@ FLAGS = flags.FLAGS
 
 
 class TestCheckout(
-    BuyerConsentCheckoutResp,
-    FulfillmentCheckout,
-    DiscountCheckoutResp,
-    Ap2Checkout,
+  BuyerConsentCheckoutResp,
+  FulfillmentCheckout,
+  DiscountCheckoutResp,
+  Ap2Checkout,
 ):
-  """Checkout model supporting Fulfillment, Discount, Buyer Consent, and AP2 extensions."""
+  """Checkout model supporting Fulfillment, Discount, and AP2 extensions."""
 
-  platform: Optional[PlatformConfig] = None
+  platform: PlatformConfig | None = None
 
 
 class IntegrationTest(absltest.TestCase):
   """Integration tests for the UCP server application."""
 
   def setUp(self) -> None:
-    """Sets up the test environment, including temporary DBs and dependencies."""
+    """Set up the test environment, including temporary DBs and dependencies."""
     super().setUp()
     # Create a temporary directory for test databases
-    self.test_dir = tempfile.mkdtemp()
-    self.products_db = os.path.join(self.test_dir, "test_products.db")
-    self.transactions_db = os.path.join(self.test_dir, "test_transactions.db")
+    self.test_dir = Path(tempfile.mkdtemp())
+    self.products_db = self.test_dir / "test_products.db"
+    self.transactions_db = self.test_dir / "test_transactions.db"
 
     # Initialize local engines and session makers
     prod_url = f"sqlite+aiosqlite:///{self.products_db}"
     self.products_engine = create_async_engine(prod_url, echo=False)
     self.products_session_factory = sessionmaker(
-        self.products_engine, expire_on_commit=False, class_=AsyncSession
+      self.products_engine, expire_on_commit=False, class_=AsyncSession
     )
 
     trans_url = f"sqlite+aiosqlite:///{self.transactions_db}"
     self.transactions_engine = create_async_engine(trans_url, echo=False)
     self.transactions_session_factory = sessionmaker(
-        self.transactions_engine, expire_on_commit=False, class_=AsyncSession
+      self.transactions_engine, expire_on_commit=False, class_=AsyncSession
     )
 
     # Initialize DB schemas locally
@@ -104,18 +112,18 @@ class IntegrationTest(absltest.TestCase):
       async with self.products_session_factory() as session:
         yield session
 
-    async def override_get_transactions_db() -> (
-        AsyncGenerator[AsyncSession, None]
-    ):
+    async def override_get_transactions_db() -> AsyncGenerator[
+      AsyncSession, None
+    ]:
       async with self.transactions_session_factory() as session:
         yield session
 
     # Apply overrides
     app.dependency_overrides[dependencies.get_products_db] = (
-        override_get_products_db
+      override_get_products_db
     )
     app.dependency_overrides[dependencies.get_transactions_db] = (
-        override_get_transactions_db
+      override_get_transactions_db
     )
 
     # Initialize Client
@@ -124,7 +132,7 @@ class IntegrationTest(absltest.TestCase):
     self._seed_data()
 
   def tearDown(self) -> None:
-    """Cleans up the test environment."""
+    """Clean up the test environment."""
     # Clear overrides
     app.dependency_overrides.clear()
 
@@ -145,28 +153,28 @@ class IntegrationTest(absltest.TestCase):
     return gid
 
   def _seed_data(self) -> None:
-    """Seeds initial test data synchronously."""
+    """Seed initial test data synchronously."""
     with self.client:
       asyncio.run(self._async_seed())
 
   async def _async_seed(self) -> None:
-    """Seeds initial test data asynchronously."""
+    """Seed initial test data asynchronously."""
     # Seed Products using local session maker
     async with self.products_session_factory() as session:
       await session.execute(delete(db.Product))
       products = [
-          db.Product(
-              id="rose",
-              title="Red Rose",
-              price=1000,
-              image_url="http://rose.com",
-          ),
-          db.Product(
-              id="tulip",
-              title="White Tulip",
-              price=800,
-              image_url="http://tulip.com",
-          ),
+        db.Product(
+          id="rose",
+          title="Red Rose",
+          price=1000,
+          image_url="http://rose.com",
+        ),
+        db.Product(
+          id="tulip",
+          title="White Tulip",
+          price=800,
+          image_url="http://tulip.com",
+        ),
       ]
       session.add_all(products)
       await session.commit()
@@ -175,24 +183,24 @@ class IntegrationTest(absltest.TestCase):
     async with self.transactions_session_factory() as session:
       await session.execute(delete(db.Inventory))
       inventory = [
-          db.Inventory(product_id="rose", quantity=5),
-          db.Inventory(product_id="tulip", quantity=2),
+        db.Inventory(product_id="rose", quantity=5),
+        db.Inventory(product_id="tulip", quantity=2),
       ]
       session.add_all(inventory)
       await session.commit()
 
   def _get_headers(
-      self,
-      idempotency_key: Optional[str] = None,
-      request_id: Optional[str] = None,
-      exclude: Optional[list[str]] = None,
-  ) -> Dict[str, str]:
-    """Constructs request headers with optional overrides."""
+    self,
+    idempotency_key: str | None = None,
+    request_id: str | None = None,
+    exclude: list[str] | None = None,
+  ) -> dict[str, str]:
+    """Construct request headers with optional overrides."""
     headers = {
-        "UCP-Agent": 'profile="https://agent.example/profile"',
-        "request-signature": "test",
-        "idempotency-key": idempotency_key or str(uuid.uuid4()),
-        "request-id": request_id or str(uuid.uuid4()),
+      "UCP-Agent": 'profile="https://agent.example/profile"',
+      "request-signature": "test",
+      "idempotency-key": idempotency_key or str(uuid.uuid4()),
+      "request-id": request_id or str(uuid.uuid4()),
     }
     if exclude:
       for key in exclude:
@@ -200,92 +208,92 @@ class IntegrationTest(absltest.TestCase):
     return headers
 
   def _create_checkout_payload(
-      self,
-      checkout_id: str,
-      items: list[tuple[str, str, int, int]],
+    self,
+    checkout_id: str,
+    items: list[tuple[str, str, int, int]],
   ) -> checkout_create_req.CheckoutCreateRequest:
-    """Helper to create a checkout payload using SDK models."""
+    """Create a checkout payload using SDK models."""
     line_items = []
     for item_id, item_title, item_price, quantity in items:
       item = item_create_req.ItemCreateRequest(
-          id=item_id, title=item_title, price=item_price
+        id=item_id, title=item_title, price=item_price
       )
       line_item = line_item_create_req.LineItemCreateRequest(
-          quantity=quantity, item=item
+        quantity=quantity, item=item
       )
       line_items.append(line_item)
 
     handler = payment_handler_create_req.PaymentHandlerCreateRequest(
-        id="google_pay",
-        name="google.pay",
-        version="2026-01-11",
-        spec="https://example.com/spec",
-        config_schema="https://example.com/schema",
-        instrument_schemas=["https://example.com/schema"],
-        config={},
+      id="google_pay",
+      name="google.pay",
+      version="2026-01-11",
+      spec="https://example.com/spec",
+      config_schema="https://example.com/schema",
+      instrument_schemas=["https://example.com/schema"],
+      config={},
     )
 
     payment = payment_create_req.PaymentCreateRequest(
-        handlers=[handler], instruments=[]
+      handlers=[handler], instruments=[]
     )
 
     # Hierarchical Fulfillment Construction
     destination = fulfillment_destination_req.FulfillmentDestinationRequest(
-        root=shipping_destination_req.ShippingDestinationRequest(
-            id="dest_1", address_country="US"
-        )
+      root=shipping_destination_req.ShippingDestinationRequest(
+        id="dest_1", address_country="US"
+      )
     )
     group = fulfillment_group_create_req.FulfillmentGroupCreateRequest(
-        selected_option_id="std-ship"
+      selected_option_id="std-ship"
     )
     method = fulfillment_method_create_req.FulfillmentMethodCreateRequest(
-        type="shipping",
-        destinations=[destination],
-        selected_destination_id="dest_1",
-        groups=[group],
+      type="shipping",
+      destinations=[destination],
+      selected_destination_id="dest_1",
+      groups=[group],
     )
     fulfillment = Fulfillment(
-        root=fulfillment_req.FulfillmentRequest(methods=[method])
+      root=fulfillment_req.FulfillmentRequest(methods=[method])
     )
 
     return checkout_create_req.CheckoutCreateRequest(
-        id=checkout_id,
-        currency="USD",
-        line_items=line_items,
-        payment=payment,
-        fulfillment=fulfillment,
+      id=checkout_id,
+      currency="USD",
+      line_items=line_items,
+      payment=payment,
+      fulfillment=fulfillment,
     )
 
   def _create_payment_payload(self) -> PaymentData:
-    """Helper to create a payment payload using SDK models."""
+    """Create a payment payload using SDK models."""
     credential = token_credential_resp.TokenCredentialResponse(
-        type="token", token="success_token"
+      type="token", token="success_token"
     )
     instrument = card_payment_instrument.CardPaymentInstrument(
-        id="instr_1",
-        handler_id="mock_payment_handler",
-        handler_name="mock_payment_handler",
-        type="card",
-        brand="Visa",
-        last_digits="1234",
-        credential=credential,
+      id="instr_1",
+      handler_id="mock_payment_handler",
+      handler_name="mock_payment_handler",
+      type="card",
+      brand="Visa",
+      last_digits="1234",
+      credential=credential,
     )
     return PaymentData(
-        payment_data=payment_instrument.PaymentInstrument(root=instrument),
-        risk_signals={},
+      payment_data=payment_instrument.PaymentInstrument(root=instrument),
+      risk_signals={},
     )
 
   def test_single_item_checkout(self) -> None:
-    """Tests the full lifecycle of a single item checkout."""
+    """Test the full lifecycle of a single item checkout."""
     with self.client:
       # 1. Create Checkout
       payload = self._create_checkout_payload(
-          "test_checkout_1", [("rose", "Red Rose", 1000, 2)]
+        "test_checkout_1", [("rose", "Red Rose", 1000, 2)]
       )
       response = self.client.post(
-          "/checkout-sessions",
-          headers=self._get_headers(idempotency_key="1", request_id="1"),
-          json=payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="1", request_id="1"),
+        json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201, f"Response: {response.text}")
       checkout = TestCheckout.model_validate(response.json())
@@ -295,16 +303,16 @@ class IntegrationTest(absltest.TestCase):
       # 2. Complete Checkout
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-          "/checkout-sessions/test_checkout_1/complete",
-          headers=self._get_headers(idempotency_key="2", request_id="2"),
-          json=payment_payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions/test_checkout_1/complete",
+        headers=self._get_headers(idempotency_key="2", request_id="2"),
+        json=payment_payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 200)
       checkout = TestCheckout.model_validate(response.json())
       self.assertEqual(checkout.status, "completed")
 
       # Verify DB State: Inventory Decremented
-      async def verify_inventory() -> Optional[int]:
+      async def verify_inventory() -> int | None:
         async with self.transactions_session_factory() as session:
           qty = await db.get_inventory(session, "rose")
           return qty
@@ -316,49 +324,49 @@ class IntegrationTest(absltest.TestCase):
       # 3. Verify Inventory Deduction
       # (Try to buy 4 more roses, only 3 should be left)
       payload = self._create_checkout_payload(
-          "test_checkout_2", [("rose", "Red Rose", 1000, 4)]
+        "test_checkout_2", [("rose", "Red Rose", 1000, 4)]
       )
       response = self.client.post(
-          "/checkout-sessions",
-          headers=self._get_headers(idempotency_key="3", request_id="3"),
-          json=payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="3", request_id="3"),
+        json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 400)
       self.assertIn("Insufficient stock", response.json()["detail"])
 
   def test_double_complete_checkout(self) -> None:
-    """Tests that completing a checkout twice is idempotent or fails gracefully."""
+    """Test that completing a checkout twice is idempotent."""
     with self.client:
       # 1. Create Checkout
       payload = self._create_checkout_payload(
-          "test_checkout_double", [("rose", "Red Rose", 1000, 1)]
+        "test_checkout_double", [("rose", "Red Rose", 1000, 1)]
       )
       response = self.client.post(
-          "/checkout-sessions",
-          headers=self._get_headers(idempotency_key="1", request_id="1"),
-          json=payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="1", request_id="1"),
+        json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
 
       # 2. Complete Checkout (First time)
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-          "/checkout-sessions/test_checkout_double/complete",
-          headers=self._get_headers(idempotency_key="2", request_id="2"),
-          json=payment_payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions/test_checkout_double/complete",
+        headers=self._get_headers(idempotency_key="2", request_id="2"),
+        json=payment_payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 200)
 
       # 3. Complete Checkout (Second time) - Should fail
       response = self.client.post(
-          "/checkout-sessions/test_checkout_double/complete",
-          headers=self._get_headers(idempotency_key="4", request_id="4"),
-          json=payment_payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions/test_checkout_double/complete",
+        headers=self._get_headers(idempotency_key="4", request_id="4"),
+        json=payment_payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 409)
       self.assertEqual(
-          response.json()["detail"],
-          "Cannot complete checkout in state 'completed'",
+        response.json()["detail"],
+        "Cannot complete checkout in state 'completed'",
       )
 
   def test_multi_item_checkout(self) -> None:
@@ -366,27 +374,27 @@ class IntegrationTest(absltest.TestCase):
     with self.client:
       # 1. Create Multi-item Checkout
       payload = self._create_checkout_payload(
-          "test_checkout_multi",
-          [("rose", "Red Rose", 1000, 1), ("tulip", "White Tulip", 800, 2)],
+        "test_checkout_multi",
+        [("rose", "Red Rose", 1000, 1), ("tulip", "White Tulip", 800, 2)],
       )
       response = self.client.post(
-          "/checkout-sessions",
-          headers=self._get_headers(idempotency_key="5", request_id="5"),
-          json=payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="5", request_id="5"),
+        json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
 
       # 2. Complete Multi-item Checkout
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-          "/checkout-sessions/test_checkout_multi/complete",
-          headers=self._get_headers(idempotency_key="6", request_id="6"),
-          json=payment_payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions/test_checkout_multi/complete",
+        headers=self._get_headers(idempotency_key="6", request_id="6"),
+        json=payment_payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 200)
 
       # Verify DB State for Multi-item
-      async def verify_multi_inventory() -> tuple[Optional[int], Optional[int]]:
+      async def verify_multi_inventory() -> tuple[int | None, int | None]:
         async with self.transactions_session_factory() as session:
           qty_rose = await db.get_inventory(session, "rose")
           qty_tulip = await db.get_inventory(session, "tulip")
@@ -402,14 +410,14 @@ class IntegrationTest(absltest.TestCase):
     """Tests that requests missing mandatory headers are rejected."""
     with self.client:
       payload = self._create_checkout_payload(
-          "test_checkout_missing_header", [("rose", "Red Rose", 1000, 1)]
+        "test_checkout_missing_header", [("rose", "Red Rose", 1000, 1)]
       )
       response = self.client.post(
-          "/checkout-sessions",
-          headers=self._get_headers(
-              idempotency_key="7", request_id="7", exclude=["UCP-Agent"]
-          ),
-          json=payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions",
+        headers=self._get_headers(
+          idempotency_key="7", request_id="7", exclude=["UCP-Agent"]
+        ),
+        json=payload.model_dump(mode="json", exclude_none=True),
       )
       # Missing header should result in 422 Unprocessable Entity (FastAPI
       # default validation)
@@ -420,23 +428,23 @@ class IntegrationTest(absltest.TestCase):
     with self.client:
       # 1. Create Checkout
       payload = self._create_checkout_payload(
-          "test_checkout_cancel", [("rose", "Red Rose", 1000, 1)]
+        "test_checkout_cancel", [("rose", "Red Rose", 1000, 1)]
       )
       response = self.client.post(
-          "/checkout-sessions",
-          headers=self._get_headers(
-              idempotency_key="cancel_1", request_id="cancel_1"
-          ),
-          json=payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions",
+        headers=self._get_headers(
+          idempotency_key="cancel_1", request_id="cancel_1"
+        ),
+        json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
 
       # 2. Cancel Checkout
       response = self.client.post(
-          "/checkout-sessions/test_checkout_cancel/cancel",
-          headers=self._get_headers(
-              idempotency_key="cancel_2", request_id="cancel_2"
-          ),
+        "/checkout-sessions/test_checkout_cancel/cancel",
+        headers=self._get_headers(
+          idempotency_key="cancel_2", request_id="cancel_2"
+        ),
       )
       self.assertEqual(response.status_code, 200)
       checkout = TestCheckout.model_validate(response.json())
@@ -444,44 +452,44 @@ class IntegrationTest(absltest.TestCase):
 
       # 3. Try to Cancel again (should fail)
       response = self.client.post(
-          "/checkout-sessions/test_checkout_cancel/cancel",
-          headers=self._get_headers(
-              idempotency_key="cancel_3", request_id="cancel_3"
-          ),
+        "/checkout-sessions/test_checkout_cancel/cancel",
+        headers=self._get_headers(
+          idempotency_key="cancel_3", request_id="cancel_3"
+        ),
       )
       self.assertEqual(response.status_code, 409)
       self.assertIn("Cannot cancel checkout", response.json()["detail"])
 
       # 4. Create another checkout and complete it, then try to cancel
       payload = self._create_checkout_payload(
-          "test_checkout_cancel_completed", [("rose", "Red Rose", 1000, 1)]
+        "test_checkout_cancel_completed", [("rose", "Red Rose", 1000, 1)]
       )
       response = self.client.post(
-          "/checkout-sessions",
-          headers=self._get_headers(
-              idempotency_key="cancel_4", request_id="cancel_4"
-          ),
-          json=payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions",
+        headers=self._get_headers(
+          idempotency_key="cancel_4", request_id="cancel_4"
+        ),
+        json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
 
       # Complete it
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-          "/checkout-sessions/test_checkout_cancel_completed/complete",
-          headers=self._get_headers(
-              idempotency_key="cancel_5", request_id="cancel_5"
-          ),
-          json=payment_payload.model_dump(mode="json", exclude_none=True),
+        "/checkout-sessions/test_checkout_cancel_completed/complete",
+        headers=self._get_headers(
+          idempotency_key="cancel_5", request_id="cancel_5"
+        ),
+        json=payment_payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 200)
 
       # Try to cancel completed checkout
       response = self.client.post(
-          "/checkout-sessions/test_checkout_cancel_completed/cancel",
-          headers=self._get_headers(
-              idempotency_key="cancel_6", request_id="cancel_6"
-          ),
+        "/checkout-sessions/test_checkout_cancel_completed/cancel",
+        headers=self._get_headers(
+          idempotency_key="cancel_6", request_id="cancel_6"
+        ),
       )
       self.assertEqual(response.status_code, 409)
       self.assertIn("Cannot cancel checkout", response.json()["detail"])

--- a/rest/python/server/models.py
+++ b/rest/python/server/models.py
@@ -19,18 +19,36 @@ These models extend the base UCP SDK models by combining multiple extensions
 objects used by the sample server implementation.
 """
 
-from typing import Optional
-
-from ucp_sdk.models.schemas.shopping.ap2_mandate import CheckoutResponseWithAp2 as Ap2Checkout
-from ucp_sdk.models.schemas.shopping.buyer_consent_create_req import Checkout as BuyerConsentCheckoutCreate
-from ucp_sdk.models.schemas.shopping.buyer_consent_resp import Checkout as BuyerConsentCheckoutResp
-from ucp_sdk.models.schemas.shopping.buyer_consent_update_req import Checkout as BuyerConsentCheckoutUpdate
-from ucp_sdk.models.schemas.shopping.discount_create_req import Checkout as DiscountCheckoutCreate
-from ucp_sdk.models.schemas.shopping.discount_resp import Checkout as DiscountCheckoutResp
-from ucp_sdk.models.schemas.shopping.discount_update_req import Checkout as DiscountCheckoutUpdate
-from ucp_sdk.models.schemas.shopping.fulfillment_create_req import Checkout as FulfillmentCreateRequest
-from ucp_sdk.models.schemas.shopping.fulfillment_resp import Checkout as FulfillmentCheckout
-from ucp_sdk.models.schemas.shopping.fulfillment_update_req import Checkout as FulfillmentUpdateRequest
+from ucp_sdk.models.schemas.shopping.ap2_mandate import (
+  CheckoutResponseWithAp2 as Ap2Checkout,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent_create_req import (
+  Checkout as BuyerConsentCheckoutCreate,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent_resp import (
+  Checkout as BuyerConsentCheckoutResp,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent_update_req import (
+  Checkout as BuyerConsentCheckoutUpdate,
+)
+from ucp_sdk.models.schemas.shopping.discount_create_req import (
+  Checkout as DiscountCheckoutCreate,
+)
+from ucp_sdk.models.schemas.shopping.discount_resp import (
+  Checkout as DiscountCheckoutResp,
+)
+from ucp_sdk.models.schemas.shopping.discount_update_req import (
+  Checkout as DiscountCheckoutUpdate,
+)
+from ucp_sdk.models.schemas.shopping.fulfillment_create_req import (
+  Checkout as FulfillmentCreateRequest,
+)
+from ucp_sdk.models.schemas.shopping.fulfillment_resp import (
+  Checkout as FulfillmentCheckout,
+)
+from ucp_sdk.models.schemas.shopping.fulfillment_update_req import (
+  Checkout as FulfillmentUpdateRequest,
+)
 from ucp_sdk.models.schemas.shopping.order import Order
 from ucp_sdk.models.schemas.shopping.order import PlatformConfig
 
@@ -40,24 +58,24 @@ class UnifiedOrder(Order):
 
 
 class UnifiedCheckout(
-    BuyerConsentCheckoutResp,
-    FulfillmentCheckout,
-    DiscountCheckoutResp,
-    Ap2Checkout,
+  BuyerConsentCheckoutResp,
+  FulfillmentCheckout,
+  DiscountCheckoutResp,
+  Ap2Checkout,
 ):
-  """Checkout model supporting Fulfillment, Discount, Buyer Consent, and AP2 extensions."""
+  """Checkout model supporting various extensions."""
 
-  platform: Optional[PlatformConfig] = None
+  platform: PlatformConfig | None = None
 
 
 class UnifiedCheckoutCreateRequest(
-    FulfillmentCreateRequest, DiscountCheckoutCreate, BuyerConsentCheckoutCreate
+  FulfillmentCreateRequest, DiscountCheckoutCreate, BuyerConsentCheckoutCreate
 ):
   """Create request model combining base fields and extensions."""
 
 
 class UnifiedCheckoutUpdateRequest(
-    FulfillmentUpdateRequest, DiscountCheckoutUpdate, BuyerConsentCheckoutUpdate
+  FulfillmentUpdateRequest, DiscountCheckoutUpdate, BuyerConsentCheckoutUpdate
 ):
   """Update request model combining base fields and extensions."""
 

--- a/rest/python/server/pyproject.toml
+++ b/rest/python/server/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "httpx>=0.26.0",
+    "ruff>=0.14.11",
 ]
 
 [build-system]
@@ -38,3 +39,23 @@ packages = ["."]
 [tool.uv.sources]
 # The relative path is stored here
 ucp-sdk = { path = "../../../../sdk/python/", editable = true }
+
+[tool.ruff]
+line-length = 80
+indent-width = 2
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B", "C4", "SIM", "N", "UP", "D", "PTH", "T20"]
+ignore = ["D203", "D213"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+force-sort-within-sections = true
+case-sensitive = true

--- a/rest/python/server/routes/__init__.py
+++ b/rest/python/server/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route definitions for the UCP server."""

--- a/rest/python/server/routes/discovery.py
+++ b/rest/python/server/routes/discovery.py
@@ -30,19 +30,19 @@ SHOP_ID = str(uuid.uuid4())
 
 
 @router.get(
-    "/.well-known/ucp",
-    response_model=UcpDiscoveryProfile,
-    summary="Get Merchant Profile",
+  "/.well-known/ucp",
+  response_model=UcpDiscoveryProfile,
+  summary="Get Merchant Profile",
 )
 async def get_merchant_profile(request: Request):
-  """Returns the merchant profile and capabilities."""
+  """Return the merchant profile and capabilities."""
   # Read template and perform simple substitution
-  with open(PROFILE_TEMPLATE_PATH, "r", encoding="utf-8") as f:
+  with PROFILE_TEMPLATE_PATH.open(encoding="utf-8") as f:
     template = f.read()
 
   # Replace placeholders
   profile_json = template.replace(
-      "{{ENDPOINT}}", str(request.base_url).rstrip("/")
+    "{{ENDPOINT}}", str(request.base_url).rstrip("/")
   ).replace("{{SHOP_ID}}", SHOP_ID)
 
   return UcpDiscoveryProfile(**json.loads(profile_json))

--- a/rest/python/server/routes/order.py
+++ b/rest/python/server/routes/order.py
@@ -14,7 +14,7 @@
 
 """Order management routes for the UCP server."""
 
-from typing import Any
+from typing import Annotated, Any
 
 import dependencies
 from fastapi import APIRouter
@@ -28,18 +28,18 @@ router = APIRouter()
 
 
 @router.get(
-    "/orders/{id}",
-    response_model=dict[str, Any],
-    operation_id="get_order",
+  "/orders/{id}",
+  response_model=dict[str, Any],
+  operation_id="get_order",
 )
 async def get_order(
-    order_id: str = Path(..., alias="id"),
-    common_headers: dependencies.CommonHeaders = Depends(
-        dependencies.common_headers
-    ),
-    checkout_service: CheckoutService = Depends(
-        dependencies.get_checkout_service
-    ),
+  order_id: Annotated[str, Path(..., alias="id")],
+  common_headers: Annotated[
+    dependencies.CommonHeaders, Depends(dependencies.common_headers)
+  ],
+  checkout_service: Annotated[
+    CheckoutService, Depends(dependencies.get_checkout_service)
+  ],
 ) -> dict[str, Any]:
   """Get an order by ID."""
   del common_headers  # Unused
@@ -47,19 +47,19 @@ async def get_order(
 
 
 @router.post(
-    "/testing/simulate-shipping/{id}",
-    response_model=dict[str, Any],
-    operation_id="ship_order",
-    dependencies=[Depends(dependencies.verify_simulation_secret)],
+  "/testing/simulate-shipping/{id}",
+  response_model=dict[str, Any],
+  operation_id="ship_order",
+  dependencies=[Depends(dependencies.verify_simulation_secret)],
 )
 async def ship_order(
-    order_id: str = Path(..., alias="id"),
-    common_headers: dependencies.CommonHeaders = Depends(
-        dependencies.common_headers
-    ),
-    checkout_service: CheckoutService = Depends(
-        dependencies.get_checkout_service
-    ),
+  order_id: Annotated[str, Path(..., alias="id")],
+  common_headers: Annotated[
+    dependencies.CommonHeaders, Depends(dependencies.common_headers)
+  ],
+  checkout_service: Annotated[
+    CheckoutService, Depends(dependencies.get_checkout_service)
+  ],
 ) -> dict[str, Any]:
   """Simulate shipping an order."""
   del common_headers  # Unused
@@ -68,19 +68,19 @@ async def ship_order(
 
 
 @router.put(
-    "/orders/{id}",
-    response_model=dict[str, Any],
-    operation_id="update_order",
+  "/orders/{id}",
+  response_model=dict[str, Any],
+  operation_id="update_order",
 )
 async def update_order(
-    order_id: str = Path(..., alias="id"),
-    order: UnifiedOrder = Body(...),
-    common_headers: dependencies.CommonHeaders = Depends(
-        dependencies.common_headers
-    ),
-    checkout_service: CheckoutService = Depends(
-        dependencies.get_checkout_service
-    ),
+  order_id: Annotated[str, Path(..., alias="id")],
+  order: Annotated[UnifiedOrder, Body(...)],
+  common_headers: Annotated[
+    dependencies.CommonHeaders, Depends(dependencies.common_headers)
+  ],
+  checkout_service: Annotated[
+    CheckoutService, Depends(dependencies.get_checkout_service)
+  ],
 ) -> dict[str, Any]:
   """Update an order."""
   del common_headers  # Unused

--- a/rest/python/server/server.py
+++ b/rest/python/server/server.py
@@ -16,7 +16,7 @@
 
 import logging
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 from absl import app as absl_app
 import config
 from exceptions import UcpError
@@ -35,26 +35,26 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI(
-    title="UCP Shopping Service",
-    version=config.get_server_version(),
-    description="Reference implementation of the UCP Shopping Service",
-    lifespan=config.lifespan,
+  title="UCP Shopping Service",
+  version=config.get_server_version(),
+  description="Reference implementation of the UCP Shopping Service",
+  lifespan=config.lifespan,
 )
 
 
 @app.exception_handler(UcpError)
 async def ucp_exception_handler(request: Request, exc: UcpError):
-  """Handles UCP-specific exceptions and converts them to JSON responses."""
+  """Handle UCP-specific exceptions and converts them to JSON responses."""
   del request  # Unused.
   return JSONResponse(
-      status_code=exc.status_code,
-      content={"detail": exc.message, "code": exc.code},
+    status_code=exc.status_code,
+    content={"detail": exc.message, "code": exc.code},
   )
 
 
 # Apply business logic implementation to generated routes
 routes.ucp_implementation.apply_implementation(
-    generated_routes.ucp_routes.router
+  generated_routes.ucp_routes.router
 )
 app.include_router(generated_routes.ucp_routes.router)
 app.include_router(order_router)
@@ -62,20 +62,20 @@ app.include_router(discovery_router)
 
 
 def main(argv: Sequence[str]) -> None:
-  """Main entry point for the UCP Merchant Server."""
+  """Run the UCP Merchant Server."""
   del argv  # Unused.
 
   if (
-      config.FLAGS.products_db_path is None
-      or config.FLAGS.transactions_db_path is None
-      or config.FLAGS.port is None
+    config.FLAGS.products_db_path is None
+    or config.FLAGS.transactions_db_path is None
+    or config.FLAGS.port is None
   ):
     logger.error(
-        "Both --products_db_path, --transactions_db_path, and --port must be"
-        " provided."
+      "Both --products_db_path, --transactions_db_path, and --port must be"
+      " provided."
     )
-    print("\nUsage:")
-    print(config.FLAGS.main_module_help())
+    print("\nUsage:")  # noqa: T201
+    print(config.FLAGS.main_module_help())  # noqa: T201
     sys.exit(1)
 
   uvicorn.run(app, host="0.0.0.0", port=config.FLAGS.port)

--- a/rest/python/server/services/__init__.py
+++ b/rest/python/server/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services for the UCP server."""


### PR DESCRIPTION
- Integrate `ruff` as the primary linter and formatter in `pyproject.toml`.
- Replace `os.path` usage with `pathlib.Path` for improved path handling.
- Update type annotations to use modern syntax (e.g., `str | None` instead of `Optional[str]`).
- Use `Annotated` for FastAPI dependencies to improve readability and tool support.
- Standardize code formatting across all Python sample files using a 2-space indentation.
- Add missing docstrings and `__init__.py` files to improve package structure and documentation.
- Address various linting warnings and modernize import statements.