### PR TITLE
fix: update invalid spec URLs in discovery profile

### DIFF
--- a/rest/python/server/routes/discovery_profile.json
+++ b/rest/python/server/routes/discovery_profile.json
@@ -4,7 +4,7 @@
     "services": {
       "dev.ucp.shopping": {
         "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping",
+        "spec": "https://ucp.dev/specification/reference",
         "rest": {
           "schema": "https://ucp.dev/services/shopping/openapi.json",
           "endpoint": "{{ENDPOINT}}"
@@ -15,54 +15,33 @@
       {
         "name": "dev.ucp.shopping.checkout",
         "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/checkout",
+        "spec": "https://ucp.dev/specification/checkout",
         "schema": "https://ucp.dev/schemas/shopping/checkout.json"
       },
       {
         "name": "dev.ucp.shopping.order",
         "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/order",
+        "spec": "https://ucp.dev/specification/order",
         "schema": "https://ucp.dev/schemas/shopping/order.json"
-      },
-      {
-        "name": "dev.ucp.shopping.refund",
-        "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/refund",
-        "schema": "https://ucp.dev/schemas/shopping/refund.json",
-        "extends": "dev.ucp.shopping.order"
-      },
-      {
-        "name": "dev.ucp.shopping.return",
-        "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/return",
-        "schema": "https://ucp.dev/schemas/shopping/return.json",
-        "extends": "dev.ucp.shopping.order"
-      },
-      {
-        "name": "dev.ucp.shopping.dispute",
-        "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/dispute",
-        "schema": "https://ucp.dev/schemas/shopping/dispute.json",
-        "extends": "dev.ucp.shopping.order"
       },
       {
         "name": "dev.ucp.shopping.discount",
         "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/discount",
+        "spec": "https://ucp.dev/specification/discount",
         "schema": "https://ucp.dev/schemas/shopping/discount.json",
         "extends": "dev.ucp.shopping.checkout"
       },
       {
         "name": "dev.ucp.shopping.fulfillment",
         "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/fulfillment",
+        "spec": "https://ucp.dev/specification/fulfillment",
         "schema": "https://ucp.dev/schemas/shopping/fulfillment.json",
         "extends": "dev.ucp.shopping.checkout"
       },
       {
         "name": "dev.ucp.shopping.buyer_consent",
         "version": "2026-01-11",
-        "spec": "https://ucp.dev/specs/shopping/buyer_consent",
+        "spec": "https://ucp.dev/specification/buyer_consent",
         "schema": "https://ucp.dev/schemas/shopping/buyer_consent.json",
         "extends": "dev.ucp.shopping.checkout"
       }
@@ -87,10 +66,10 @@
         "id": "google_pay",
         "name": "google.pay",
         "version": "2026-01-11",
-        "spec": "https://example.com/spec",
-        "config_schema": "https://example.com/schema",
+        "spec": "https://developers.google.com/merchant/ucp/guides/gpay-payment-handler",
+        "config_schema": "https://pay.google.com/gp/p/ucp/2026-01-11/schemas/gpay_config.json",
         "instrument_schemas": [
-          "https://ucp.dev/schemas/shopping/types/gpay_card_payment_instrument.json"
+          "https://pay.google.com/gp/p/ucp/2026-01-11/schemas/gpay_card_payment_instrument.json"
         ],
         "config": {
           "api_version": 2,


### PR DESCRIPTION
Related to https://github.com/Universal-Commerce-Protocol/samples/pull/7, where we have outdated links pointing to `https://ucp.dev/specs/shopping/...` that should be updated to `https://ucp.dev/specification/...` in `rest/python/server`.

Also clean up obsolete extension definitions in profile from `Order` capability:
- disputes
- returns
- refunds

This update ensure that discovery responses from sample implementations point to valid, working specification pages and serve as a template for https://github.com/Universal-Commerce-Protocol/samples/pull/7