### PR TITLE
feat: implement 'requires_escalation' triggered by risk signals

### DIFF
--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -76,3 +76,11 @@ class InvalidRequestError(UcpError):
   def __init__(self, message: str):
     """Initialize InvalidRequestError."""
     super().__init__(message, code="INVALID_REQUEST", status_code=400)
+
+
+class Ap2VerificationError(UcpError):
+  """Raised when AP2 mandate verification fails."""
+
+  def __init__(self, message: str, code: str = "mandate_invalid_signature"):
+    """Initialize Ap2VerificationError."""
+    super().__init__(message, code=code, status_code=400)

--- a/rest/python/server/server.py
+++ b/rest/python/server/server.py
@@ -52,6 +52,15 @@ async def ucp_exception_handler(request: Request, exc: UcpError):
   )
 
 
+@app.get("/recover/{checkout_id}")
+async def recover_checkout(checkout_id: str):
+  """Mock checkout recovery UI."""
+  return {
+    "message": f"Recovering checkout {checkout_id}",
+    "status": "ui_rendering",
+  }
+
+
 # Apply business logic implementation to generated routes
 routes.ucp_implementation.apply_implementation(
   generated_routes.ucp_routes.router


### PR DESCRIPTION
Why:
- To enable conformance testing of the checkout escalation flow according to spec.
- Provides a deterministic way to trigger 'requires_escalation' via 'risk_signals' payload in 'complete_checkout'.

What:
- Removed hardcoded buyer name check.
- Updated 'complete_checkout' to check for 'simulation_trigger': 'escalation_required' in 'risk_signals'.
- When triggered, returns 200 OK with status 'requires_escalation', 'continue_url', and 'requires_buyer_input' message, instead of completing the order.