### PR TITLE
feat: implement mock AP2 signature verification

### DIFF
--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -76,3 +76,11 @@ class InvalidRequestError(UcpError):
   def __init__(self, message: str):
     """Initialize InvalidRequestError."""
     super().__init__(message, code="INVALID_REQUEST", status_code=400)
+
+
+class Ap2VerificationError(UcpError):
+  """Raised when AP2 mandate verification fails."""
+
+  def __init__(self, message: str, code: str = "mandate_invalid_signature"):
+    """Initialize Ap2VerificationError."""
+    super().__init__(message, code=code, status_code=400)


### PR DESCRIPTION
Why:
- To verify that the server correctly rejects invalid AP2 mandates with the appropriate error code.
- Required for conformance testing of the AP2 security flow.

What:
- Added 'Ap2VerificationError' to exceptions.
- Implemented '_verify_ap2_mandate' in 'CheckoutService' to reject mandates containing the substring 'invalid_signature'.
- Updated 'complete_checkout' to invoke this verification.