### PR TITLE
fix(server): align Python sample server with UCP 2026-04-08

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -45,14 +45,16 @@ from ucp_sdk.models.schemas.shopping import (
 from ucp_sdk.models.schemas.shopping.types import (
   payment_instrument as payment_instr_type,
 )
-from ucp_sdk.models.schemas.shopping.ap2_mandate import Checkout as Ap2Checkout
-from ucp_sdk.models.schemas.shopping.buyer_consent import (
+from ucp_sdk.models.schemas.shopping.ap2_mandate.dev.ucp.shopping import (
+  Checkout as Ap2Checkout,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent.dev.ucp.shopping import (
   Checkout as BuyerConsentCheckoutResp,
 )
-from ucp_sdk.models.schemas.shopping.discount import (
+from ucp_sdk.models.schemas.shopping.discount.dev.ucp.shopping import (
   Checkout as DiscountCheckoutResp,
 )
-from ucp_sdk.models.schemas.shopping.fulfillment import (
+from ucp_sdk.models.schemas.shopping.fulfillment.dev.ucp.shopping import (
   Checkout as FulfillmentCheckout,
 )
 from ucp_sdk.models.schemas.shopping.order import PlatformSchema

--- a/rest/python/server/models.py
+++ b/rest/python/server/models.py
@@ -20,17 +20,19 @@ objects used by the sample server implementation.
 """
 
 from typing import Any
-from ucp_sdk.models.schemas.shopping.ap2_mandate import Checkout as Ap2Checkout
-from ucp_sdk.models.schemas.shopping.buyer_consent import (
+from ucp_sdk.models.schemas.shopping.ap2_mandate.dev.ucp.shopping import (
+  Checkout as Ap2Checkout,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent.dev.ucp.shopping import (
   Checkout as BuyerConsentCheckoutResp,
 )
-from ucp_sdk.models.schemas.shopping.discount import (
+from ucp_sdk.models.schemas.shopping.discount import DiscountsObject
+from ucp_sdk.models.schemas.shopping.discount.dev.ucp.shopping import (
   Checkout as DiscountCheckoutResp,
-  DiscountsObject,
 )
-from ucp_sdk.models.schemas.shopping.fulfillment import (
+from ucp_sdk.models.schemas.shopping.fulfillment import Fulfillment
+from ucp_sdk.models.schemas.shopping.fulfillment.dev.ucp.shopping import (
   Checkout as FulfillmentCheckout,
-  Fulfillment,
 )
 
 from ucp_sdk.models.schemas.shopping.order import Order

--- a/rest/python/server/routes/discovery_profile.json
+++ b/rest/python/server/routes/discovery_profile.json
@@ -1,72 +1,72 @@
 {
   "ucp": {
-    "version": "2026-01-23",
+    "version": "2026-04-08",
     "services": {
       "dev.ucp.shopping": [
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/overview",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/overview",
           "transport": "rest",
           "endpoint": "{{ENDPOINT}}",
-          "schema": "https://ucp.dev/2026-01-23/services/shopping/openapi.json"
+          "schema": "https://ucp.dev/2026-04-08/services/shopping/openapi.json"
         },
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/overview",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/overview",
           "transport": "mcp",
           "endpoint": "{{ENDPOINT}}/mcp",
-          "schema": "https://ucp.dev/2026-01-23/services/shopping/openrpc.json"
+          "schema": "https://ucp.dev/2026-04-08/services/shopping/openrpc.json"
         },
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/overview",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/overview",
           "transport": "a2a",
           "endpoint": "{{ENDPOINT}}/.well-known/agent-card.json"
         },
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/overview",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/overview",
           "transport": "embedded",
-          "schema": "https://ucp.dev/2026-01-23/services/shopping/embedded.json"
+          "schema": "https://ucp.dev/2026-04-08/services/shopping/embedded.json"
         }
       ]
     },
     "capabilities": {
       "dev.ucp.shopping.checkout": [
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/checkout",
-          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json"
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/checkout",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
         }
       ],
       "dev.ucp.shopping.order": [
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/order",
-          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/order.json"
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/order",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/order.json"
         }
       ],
       "dev.ucp.shopping.discount": [
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/discount",
-          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/discount.json",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/discount",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/discount.json",
           "extends": "dev.ucp.shopping.checkout"
         }
       ],
       "dev.ucp.shopping.fulfillment": [
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/fulfillment",
-          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/fulfillment.json",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/fulfillment",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/fulfillment.json",
           "extends": "dev.ucp.shopping.checkout"
         }
       ],
       "dev.ucp.shopping.buyer_consent": [
         {
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/buyer-consent",
-          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/buyer_consent.json",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/buyer-consent",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/buyer_consent.json",
           "extends": "dev.ucp.shopping.checkout"
         }
       ]
@@ -76,11 +76,11 @@
         {
           "id": "shop_pay",
           "name": "com.shopify.shop_pay",
-          "version": "2026-01-23",
+          "version": "2026-04-08",
           "spec": "https://shopify.dev/docs/agents/checkout/shop-pay-handler",
-          "config_schema": "https://shopify.dev/ucp/shop-pay-handler/2026-01-23/config.json",
+          "config_schema": "https://shopify.dev/ucp/shop-pay-handler/2026-04-08/config.json",
           "instrument_schemas": [
-            "https://shopify.dev/ucp/shop-pay-handler/2026-01-23/instrument.json"
+            "https://shopify.dev/ucp/shop-pay-handler/2026-04-08/instrument.json"
           ],
           "config": {
             "shop_id": "{{SHOP_ID}}"
@@ -91,11 +91,11 @@
         {
           "id": "google_pay",
           "name": "com.google.pay",
-          "version": "2026-01-23",
-          "spec": "https://pay.google.com/gp/p/ucp/2026-01-23/",
-          "config_schema": "https://pay.google.com/gp/p/ucp/2026-01-23/schemas/config.json",
+          "version": "2026-04-08",
+          "spec": "https://pay.google.com/gp/p/ucp/2026-04-08/",
+          "config_schema": "https://pay.google.com/gp/p/ucp/2026-04-08/schemas/config.json",
           "instrument_schemas": [
-            "https://pay.google.com/gp/p/ucp/2026-01-23/schemas/card_payment_instrument.json"
+            "https://pay.google.com/gp/p/ucp/2026-04-08/schemas/card_payment_instrument.json"
           ],
           "config": {
             "api_version": 2,
@@ -132,8 +132,8 @@
         {
           "id": "mock_payment_handler",
           "name": "mock_payment_handler",
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/schemas/mock_payment_handler/spec",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/schemas/mock_payment_handler/spec",
           "config": {}
         }
       ]

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -783,7 +783,7 @@ class CheckoutService:
         ucp=UcpMetadata(
           root=ResponseOrder(
             version=getattr(
-              checkout.ucp.root, "version", Version("2026-01-23")
+              checkout.ucp.root, "version", Version("2026-04-08")
             ),
             capabilities={
               getattr(k, "root", k): v
@@ -798,7 +798,11 @@ class CheckoutService:
         checkout_id=checkout.id,
         permalink_url=checkout.order.permalink_url,
         line_items=order_line_items,
-        totals=[total_resp.Total(**t.model_dump()) for t in checkout.totals],
+        currency=checkout.currency,
+        totals=[
+          t.model_dump(mode="json", by_alias=True, exclude_none=True)
+          for t in getattr(checkout.totals, "root", checkout.totals)
+        ],
         fulfillment=OrderFulfillment(expectations=expectations, events=[]),
       )
 
@@ -1134,9 +1138,12 @@ class CheckoutService:
                   (t.amount for t in selected_opt.totals if t.type == "total"),
                   0,
                 )
-                grand_total += opt_total
+                opt_total_value = getattr(opt_total, "root", opt_total)
+                grand_total += opt_total_value
                 checkout.totals.append(
-                  TotalResponse(type="fulfillment", amount=opt_total)
+                  TotalResponse(
+                    type="fulfillment", amount=opt_total_value
+                  )
                 )
 
     # Discount Logic


### PR DESCRIPTION
## Summary

Aligns the Python sample merchant server with the official UCP `2026-04-08` release.

Dependency chain for April validation:
- `Universal-Commerce-Protocol/python-sdk#28`
- this PR
- `Universal-Commerce-Protocol/conformance#41`

This PR updates the Python server runtime to the April SDK/model layout so it can act as the reference merchant validation target for the April conformance suite.

## Changes

- update Python server imports to the April SDK layout for extension checkout models:
  - `ap2_mandate.dev.ucp.shopping`
  - `buyer_consent.dev.ucp.shopping`
  - `discount.dev.ucp.shopping`
  - `fulfillment.dev.ucp.shopping`
- update discovery profile version/spec/schema URLs from `2026-01-23` to `2026-04-08`
- fix checkout completion order construction for April SDK model requirements by:
  - carrying `currency` into the generated `Order`
  - serializing `totals` in the shape expected by the April models
- fix fulfillment total accumulation when option totals are wrapped by April scalar/root models

## Why

After switching the Python sample server to the April SDK branch, the server still had January-era assumptions in extension imports and in checkout completion order construction. That caused the sample merchant server to fail when used as the validation target for the April conformance suite.

## Validation

Validated with:
- `python-sdk#28`
- local conformance branch from `Universal-Commerce-Protocol/conformance#41`

Results:
- `rest/python/server/integration_test.py` OK (`5 passed`)
- updated Python sample server successfully served as the merchant target for the April conformance run backing `conformance#41`

## Scope

Included here:
- runtime Python server compatibility with April SDK model layout and order serialization
- April discovery profile metadata for the Python sample server

Not included here:
- README/documentation refresh for remaining January examples
- Python SDK generator/model changes
- conformance test updates themselves