### PR TITLE
feat: add Goofre ACO reference implementation sample

### DIFF
--- a/aco/goofre-aco/README.md
+++ b/aco/goofre-aco/README.md
@@ -1,0 +1,26 @@
+# Goofre ACO - Agentic Commerce Orchestrator
+
+**UCP Conformance:** v1.2 (baseline 2026-01-23)
+
+## The problem
+
+A merchant has GMC, GA4, GBP, a Magento catalog, and a POS. None talk to each
+other. When a Gemini agent asks "is this available for pickup in Brooklyn?", the
+answer requires synthesizing inventory, availability, and checkout eligibility in
+real time. An Agentic Commerce Orchestrator (ACO) does that synthesis. This sample
+shows the UCP shapes that flow through one.
+
+## Contents
+
+- schema-demo/ - UCPProduct, UCPCartEvent (RFC #355 identity), UCPOrderEvent (AP2), UCPInsight, B2B order
+- mcp-integration/ - Drop-in config for Claude Desktop / Copilot (6 MCP tools)
+- a2a-negotiation/ - B2C pickup intent + B2B procurement intent with MOQ/Net Terms
+
+## Vendor namespace extensions
+
+- com.goofre.agentic_trust_score - AI discoverability scoring (additive, ignorable)
+- com.goofre.b2b_wholesale - MOQ, tiered pricing, Net Terms, KYB (additive, ignorable)
+
+## Source
+
+https://github.com/Goofre-Agentic-Commerce-Orchestrator/agentic_commerce_orchestrator_ACO

--- a/aco/goofre-aco/a2a-negotiation/intent-b2b.json
+++ b/aco/goofre-aco/a2a-negotiation/intent-b2b.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "B2B Procurement Intent. Constraints: requireMOQ=true, requireNetTerms=true, authorizedBudget=$5000. If qty<50: status=partial.",
+  "intentId": "procurement-bot-po2026-0441",
+  "intentType": "initiate_cart",
+  "agentId": "procurement-bot-v1",
+  "businessId": "CORP-AMAZON-001",
+  "payload": { "id": "SKU-BULK-CANVAS-BOX", "quantity": 100 },
+  "constraints": {
+    "requireMOQ": true,
+    "requireNetTerms": true,
+    "authorizedBudget": { "amount": 5000.00, "currency": "USD" }
+  }
+}

--- a/aco/goofre-aco/a2a-negotiation/intent-b2c.json
+++ b/aco/goofre-aco/a2a-negotiation/intent-b2c.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "B2C CommerceIntent. Constraints: requirePickupAvailable, requiredChannel=local, maxPrice=$100. Expected: fulfilled with BOPIS localInventory.",
+  "intentId": "gemini-shop-a7f3c2-20260505",
+  "intentType": "check_inventory",
+  "agentId": "gemini-shopping-agent-v2",
+  "payload": { "productId": "google-merchant::6853209410", "locationId": "store-brooklyn" },
+  "constraints": {
+    "requirePickupAvailable": true,
+    "requiredChannel": "local",
+    "maxPrice": { "amount": 100.00, "currency": "USD" }
+  }
+}

--- a/aco/goofre-aco/mcp-integration/mcp_config.json
+++ b/aco/goofre-aco/mcp-integration/mcp_config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "goofre": {
+      "command": "node",
+      "args": ["./node_modules/@goofre/mcp-server/dist/index.js"],
+      "env": {
+        "GOOFRE_PLUGIN_ID": "google-merchant",
+        "GOOFRE_GMC_MERCHANT_ID": "YOUR_GMC_MERCHANT_ID"
+      }
+    }
+  }
+}

--- a/aco/goofre-aco/schema-demo/b2b-order.json
+++ b/aco/goofre-aco/schema-demo/b2b-order.json
@@ -1,0 +1,39 @@
+{
+    "_comment": "B2B UCPOrderEvent. com.goofre.b2b_wholesale extension: MOQ=50, 100 units ordered, Distributor Price $18.50/unit, Net 30, KYB verified.",
+    "ucpId": "b2b-manufacturer::order-PO-2026-0441",
+    "ucpVersion": "1.2",
+    "sourceId": "order-PO-2026-0441",
+    "sourcePlatform": "b2b-manufacturer",
+    "normalizedAt": "2026-05-05T11:30:00Z",
+    "orderId": "order-PO-2026-0441",
+    "eventType": "order.created",
+    "lineItems": [
+          {
+                  "productUcpId": "b2b-manufacturer::SKU-BULK-CANVAS-BOX",
+                  "title": "Canvas Tote Bulk Case",
+                  "quantity": 100,
+                  "unitPrice": { "amount": 18.50, "currency": "USD" },
+                  "totalPrice": { "amount": 1850.00, "currency": "USD" }
+          }
+    ],
+    "subtotal": { "amount": 1850.00, "currency": "USD" },
+    "total": { "amount": 1850.00, "currency": "USD" },
+    "currency": "USD",
+    "occurredAt": { "iso8601": "2026-05-05T11:30:00Z", "epochMs": 1746444600000 },
+    "idempotencyKey": "po-2026-0441-attempt-1",
+    "b2bWholesale": {
+          "namespace": "com.goofre.b2b_wholesale",
+          "version": "1.0.0",
+          "minimumOrderQuantity": 50,
+          "tieredPricing": [
+                  { "minQuantity": 1, "maxQuantity": 49, "unitPrice": { "amount": 24.99, "currency": "USD" }, "label": "MSRP" },
+                  { "minQuantity": 50, "maxQuantity": 199, "unitPrice": { "amount": 18.50, "currency": "USD" }, "label": "Distributor Price" },
+                  { "minQuantity": 200, "unitPrice": { "amount": 14.00, "currency": "USD" }, "label": "Key Account Rate" }
+          ],
+          "acceptedPaymentTerms": ["net_30", "net_60", "prepaid"],
+          "requiresKYB": true,
+          "kybStatus": "verified",
+          "bulkLeadTimeDays": 5,
+          "purchaseOrderNumber": "PO-2026-0441"
+    }
+}

--- a/aco/goofre-aco/schema-demo/cart.json
+++ b/aco/goofre-aco/schema-demo/cart.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "UCPCartEvent with identityLink (RFC #355 OAuth delegated identity) applying loyalty price $79. AP2 idempotencyKey at top level.",
+  "ucpId": "google-merchant::cart-77f3a2c8",
+  "ucpVersion": "1.2",
+  "sourceId": "cart-77f3a2c8",
+  "sourcePlatform": "google-merchant",
+  "normalizedAt": "2026-05-05T15:00:00Z",
+  "cartId": "cart-77f3a2c8",
+  "action": "cart.checkout_initiated",
+  "lineItems": [
+    {
+      "productUcpId": "google-merchant::6853209410",
+      "title": "Goofre ACO Pro Tote - Midnight Canvas",
+      "quantity": 1,
+      "unitPrice": { "amount": 79.00, "currency": "USD" },
+      "ucpCheckoutEligible": true
+    }
+  ],
+  "subtotal": { "amount": 79.00, "currency": "USD" },
+  "currency": "USD",
+  "occurredAt": { "iso8601": "2026-05-05T15:00:00Z", "epochMs": 1746454800000 },
+  "ucpCheckoutEligible": true,
+  "idempotencyKey": "cart-77f3a2c8-attempt-1",
+  "identityLink": {
+    "idpProvider": "google",
+    "subjectId": "sub_9f3c2a71d8e4b56a",
+    "idpScopeGranted": ["loyalty", "payments"],
+    "linkedAt": "2026-05-05T14:55:00Z",
+    "displayName": "E. Beckett"
+  }
+}

--- a/aco/goofre-aco/schema-demo/product.json
+++ b/aco/goofre-aco/schema-demo/product.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "UCPProduct from GMC Merchant API v1. com.goofre.agentic_trust_score extension shows AI discoverability health.",
+  "ucpId": "google-merchant::6853209410",
+  "ucpVersion": "1.2",
+  "sourceId": "6853209410",
+  "sourcePlatform": "google-merchant",
+  "normalizedAt": "2026-05-05T14:32:00Z",
+  "title": "Goofre ACO Pro Tote - Midnight Canvas",
+  "brand": "Goofre Goods",
+  "status": "active",
+  "price": { "amount": 89.00, "currency": "USD" },
+  "inventory": { "available": 147, "reserved": 12, "locationId": "warehouse-us-east" },
+  "gtin": "0885909456826",
+  "channel": "omnichannel",
+  "ucpEligibility": { "ucpCheckout": true },
+  "loyaltyProgram": {
+    "programLabel": "Goofre Rewards",
+    "price": { "amount": 79.00, "currency": "USD" }
+  },
+  "agenticTrustScore": {
+    "namespace": "com.goofre.agentic_trust_score",
+    "version": "1.0.0",
+    "score": 0.87,
+    "tier": "trusted",
+    "syncHealth": [
+      { "surface": "GMC", "status": "healthy", "lastSyncedAt": "2026-05-05T14:30:00Z", "stalenessMins": 2 },
+      { "surface": "GBP", "status": "stale", "lastSyncedAt": "2026-05-03T09:00:00Z", "stalenessMins": 3332, "signal": "GBP: In-store availability not updated in 2+ days." }
+    ],
+    "schemaCompleteness": { "completeness": 0.94, "missingFields": [], "violatingFields": [] },
+    "computedAt": "2026-05-05T14:32:00Z",
+    "topActions": ["Update GBP in-store stock - agents are surfacing pickup as unavailable due to 2-day stale sync."]
+  }
+}


### PR DESCRIPTION
Adds a complete Agentic Commerce Orchestrator (ACO) reference implementation demonstrating multi-transport UCP integration.

**Schema samples** (`schema-demo/`):
- `product.json` — UCPProduct + `com.goofre.agentic_trust_score` vendor extension (AI discoverability scoring)
- `cart.json` — UCPCartEvent with `identityLink` (RFC #355 OAuth delegated identity) and AP2 `idempotencyKey`
- `b2b-order.json` — UCPOrderEvent + `com.goofre.b2b_wholesale` vendor extension (MOQ=50, tiered pricing, Net 30 terms, KYB verified, PO number)

**A2A negotiation** (`a2a-negotiation/`):
- B2C: pickup availability + maxPrice constraint
- B2B: MOQ + Net Terms + authorizedBudget procurement intent

**MCP integration** (`mcp-integration/`): Drop-in Claude Desktop / Copilot config.

Both `com.goofre.*` vendor extensions are additive — agents that don't recognize the namespace safely ignore them per the schema authoring spec.

All fixtures pass the UCP Conformance Gate (baseline 2026-01-23).

Source: https://github.com/Goofre-Agentic-Commerce-Orchestrator/agentic_commerce_orchestrator_ACO