### PR TITLE
fix(rest/python): stop null-padding unset optional fields in checkout responses

### DIFF
--- a/rest/nodejs/src/utils/validation.ts
+++ b/rest/nodejs/src/utils/validation.ts
@@ -11,8 +11,7 @@ import * as z from "zod";
  */
 export function prettyValidation<T>(
   result:
-    | { success: true; data: T; target: string }
-    | { success: false; error: any },
+    { success: true; data: T; target: string } | { success: false; error: any },
   c: Context
 ) {
   if (result.success) {

--- a/rest/python/server/generated_routes/ucp_routes.py
+++ b/rest/python/server/generated_routes/ucp_routes.py
@@ -15,6 +15,7 @@ router = APIRouter()
 @router.post(
   "/checkout-sessions",
   response_model=ucp_sdk.models.schemas.shopping.checkout.Checkout,
+  response_model_exclude_none=True,
   status_code=201,
   operation_id="create_checkout",
   summary="Create Checkout",
@@ -43,6 +44,7 @@ async def create_checkout(
 @router.get(
   "/checkout-sessions/{id}",
   response_model=ucp_sdk.models.schemas.shopping.checkout.Checkout,
+  response_model_exclude_none=True,
   status_code=200,
   operation_id="get_checkout",
   summary="Get Checkout",
@@ -68,6 +70,7 @@ async def get_checkout(
 @router.put(
   "/checkout-sessions/{id}",
   response_model=ucp_sdk.models.schemas.shopping.checkout.Checkout,
+  response_model_exclude_none=True,
   status_code=200,
   operation_id="update_checkout",
   summary="Update Checkout",
@@ -97,6 +100,7 @@ async def update_checkout(
 @router.post(
   "/checkout-sessions/{id}/complete",
   response_model=ucp_sdk.models.schemas.shopping.checkout.Checkout,
+  response_model_exclude_none=True,
   status_code=200,
   operation_id="complete_checkout",
   summary="Complete Checkout",
@@ -123,6 +127,7 @@ async def complete_checkout(
 @router.post(
   "/checkout-sessions/{id}/cancel",
   response_model=ucp_sdk.models.schemas.shopping.checkout.Checkout,
+  response_model_exclude_none=True,
   status_code=200,
   operation_id="cancel_checkout",
   summary="Cancel Checkout",
@@ -148,6 +153,7 @@ async def cancel_checkout(
 @router.post(
   "/webhooks/partners/{partner_id}/events/order",
   response_model=dict,
+  response_model_exclude_none=True,
   status_code=200,
   operation_id="order_event_webhook",
   summary="Order Event Webhook",

--- a/rest/python/server/routes/ucp_implementation.py
+++ b/rest/python/server/routes/ucp_implementation.py
@@ -229,7 +229,9 @@ async def complete_checkout(
     idempotency_key,
     checkout_complete=checkout_complete,
   )
-  return checkout_result.model_dump(mode="json", by_alias=True, exclude_none=True)
+  return checkout_result.model_dump(
+    mode="json", by_alias=True, exclude_none=True
+  )
 
 
 async def cancel_checkout(

--- a/rest/python/server/routes/ucp_implementation.py
+++ b/rest/python/server/routes/ucp_implementation.py
@@ -159,7 +159,7 @@ async def create_checkout(
   result = await checkout_service.create_checkout(
     unified_req, idempotency_key, platform_config
   )
-  return result.model_dump(mode="json", by_alias=True)
+  return result.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
 async def get_checkout(
@@ -174,7 +174,7 @@ async def get_checkout(
   """Get Checkout Implementation."""
   del common_headers  # Unused
   result = await checkout_service.get_checkout(checkout_id)
-  return result.model_dump(mode="json", by_alias=True)
+  return result.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
 async def update_checkout(
@@ -200,7 +200,7 @@ async def update_checkout(
   result = await checkout_service.update_checkout(
     checkout_id, unified_req, idempotency_key, platform_config
   )
-  return result.model_dump(mode="json", by_alias=True)
+  return result.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
 async def complete_checkout(
@@ -229,7 +229,7 @@ async def complete_checkout(
     idempotency_key,
     checkout_complete=checkout_complete,
   )
-  return checkout_result.model_dump(mode="json", by_alias=True)
+  return checkout_result.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
 async def cancel_checkout(
@@ -295,6 +295,7 @@ def apply_implementation(router: APIRouter) -> None:
         endpoint=impl,
         methods=route.methods,
         response_model=route.response_model,
+        response_model_exclude_none=route.response_model_exclude_none,
         status_code=route.status_code,
         tags=route.tags,
         summary=route.summary,

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -339,7 +339,9 @@ class CheckoutService:
 
     checkout.status = CheckoutStatus.READY_FOR_COMPLETE
 
-    response_body = checkout.model_dump(mode="json", by_alias=True, exclude_none=True)
+    response_body = checkout.model_dump(
+      mode="json", by_alias=True, exclude_none=True
+    )
 
     # Persist checkout to Transactions DB
     await db.save_checkout(
@@ -591,7 +593,9 @@ class CheckoutService:
     await self._recalculate_totals(existing)
     await self._validate_inventory(existing)
 
-    response_body = existing.model_dump(mode="json", by_alias=True, exclude_none=True)
+    response_body = existing.model_dump(
+      mode="json", by_alias=True, exclude_none=True
+    )
 
     await db.save_checkout(
       self.transactions_session,
@@ -701,7 +705,9 @@ class CheckoutService:
       checkout.order = OrderConfirmation(
         id=order_id, permalink_url=order_permalink_url
       )
-      response_body = checkout.model_dump(mode="json", by_alias=True, exclude_none=True)
+      response_body = checkout.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      )
 
       # Create and persist Order
       expectations = []
@@ -929,7 +935,9 @@ class CheckoutService:
     self._ensure_modifiable(checkout, "cancel")
 
     checkout.status = CheckoutStatus.CANCELED
-    response_body = checkout.model_dump(mode="json", by_alias=True, exclude_none=True)
+    response_body = checkout.model_dump(
+      mode="json", by_alias=True, exclude_none=True
+    )
 
     await db.save_checkout(
       self.transactions_session,

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -339,7 +339,7 @@ class CheckoutService:
 
     checkout.status = CheckoutStatus.READY_FOR_COMPLETE
 
-    response_body = checkout.model_dump(mode="json", by_alias=True)
+    response_body = checkout.model_dump(mode="json", by_alias=True, exclude_none=True)
 
     # Persist checkout to Transactions DB
     await db.save_checkout(
@@ -591,7 +591,7 @@ class CheckoutService:
     await self._recalculate_totals(existing)
     await self._validate_inventory(existing)
 
-    response_body = existing.model_dump(mode="json", by_alias=True)
+    response_body = existing.model_dump(mode="json", by_alias=True, exclude_none=True)
 
     await db.save_checkout(
       self.transactions_session,
@@ -701,7 +701,7 @@ class CheckoutService:
       checkout.order = OrderConfirmation(
         id=order_id, permalink_url=order_permalink_url
       )
-      response_body = checkout.model_dump(mode="json", by_alias=True)
+      response_body = checkout.model_dump(mode="json", by_alias=True, exclude_none=True)
 
       # Create and persist Order
       expectations = []
@@ -929,7 +929,7 @@ class CheckoutService:
     self._ensure_modifiable(checkout, "cancel")
 
     checkout.status = CheckoutStatus.CANCELED
-    response_body = checkout.model_dump(mode="json", by_alias=True)
+    response_body = checkout.model_dump(mode="json", by_alias=True, exclude_none=True)
 
     await db.save_checkout(
       self.transactions_session,


### PR DESCRIPTION
## Problem

The Flower Shop server echoes unset optional fields as explicit `null`s in checkout responses. Reproduction against main @ 827c522: POST `/checkout-sessions` with

```json
"buyer": {"first_name": "…", "email": "…", "consent": {"marketing": true, "analytics": false}}
```

returns

```json
"buyer": {"…": "…", "phone_number": null, "consent": {"analytics": false, "preferences": null, "marketing": true, "sale_of_data": null}}
```

The 2026-01-23 `buyer_consent`/`buyer` schemas type these fields as bare `"type": "boolean"` / `"type": "string"`, and under JSON Schema 2020-12 `null` is a distinct type — so the server's own responses fail validation against the spec schemas (verified with the `ucp-schema` validator: `/preferences: null is not of type "boolean"`, `/sale_of_data: null is not of type "boolean"`).

## Fix (response serialization only, three coordinated parts)

1. **`generated_routes/ucp_routes.py`** — `response_model_exclude_none=True` on the checkout routes.
2. **`routes/ucp_implementation.py`** — the route re-registration rebuilds each `APIRoute` but previously dropped `response_model_exclude_none`; now propagated. (Without this, part 1 has no effect.)
3. **Response-path `model_dump` sites** (create/get/update/complete/cancel response bodies) — `exclude_none=True`, which also cleans the idempotency-replayed stored bodies and dict subtrees FastAPI passes through as-is.

Storage/inbound dumps and the request-hash canonicalization (`json.dumps(..., sort_keys=True)`) are deliberately untouched.

## Verification

- Fresh create, idempotent replay, and the full response tree now contain **zero** null-padded fields; the `consent` object validates cleanly against the 2026-01-23 schema via `ucp-schema`.
- `integration_test.py`: 5 passed (unchanged collection).

Found while building an unofficial UCP conformance test suite (https://spck.dev).