### PR TITLE
fix(python): update extension checkout imports

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -45,14 +45,16 @@ from ucp_sdk.models.schemas.shopping import (
 from ucp_sdk.models.schemas.shopping.types import (
   payment_instrument as payment_instr_type,
 )
-from ucp_sdk.models.schemas.shopping.ap2_mandate import Checkout as Ap2Checkout
-from ucp_sdk.models.schemas.shopping.buyer_consent import (
+from ucp_sdk.models.schemas.shopping.ap2_mandate.dev.ucp.shopping import (
+  Checkout as Ap2Checkout,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent.dev.ucp.shopping import (
   Checkout as BuyerConsentCheckoutResp,
 )
-from ucp_sdk.models.schemas.shopping.discount import (
+from ucp_sdk.models.schemas.shopping.discount.dev.ucp.shopping import (
   Checkout as DiscountCheckoutResp,
 )
-from ucp_sdk.models.schemas.shopping.fulfillment import (
+from ucp_sdk.models.schemas.shopping.fulfillment.dev.ucp.shopping import (
   Checkout as FulfillmentCheckout,
 )
 from ucp_sdk.models.schemas.shopping.order import PlatformSchema

--- a/rest/python/server/models.py
+++ b/rest/python/server/models.py
@@ -20,17 +20,19 @@ objects used by the sample server implementation.
 """
 
 from typing import Any
-from ucp_sdk.models.schemas.shopping.ap2_mandate import Checkout as Ap2Checkout
-from ucp_sdk.models.schemas.shopping.buyer_consent import (
+from ucp_sdk.models.schemas.shopping.ap2_mandate.dev.ucp.shopping import (
+  Checkout as Ap2Checkout,
+)
+from ucp_sdk.models.schemas.shopping.buyer_consent.dev.ucp.shopping import (
   Checkout as BuyerConsentCheckoutResp,
 )
-from ucp_sdk.models.schemas.shopping.discount import (
+from ucp_sdk.models.schemas.shopping.discount import DiscountsObject
+from ucp_sdk.models.schemas.shopping.discount.dev.ucp.shopping import (
   Checkout as DiscountCheckoutResp,
-  DiscountsObject,
 )
-from ucp_sdk.models.schemas.shopping.fulfillment import (
+from ucp_sdk.models.schemas.shopping.fulfillment import Fulfillment
+from ucp_sdk.models.schemas.shopping.fulfillment.dev.ucp.shopping import (
   Checkout as FulfillmentCheckout,
-  Fulfillment,
 )
 
 from ucp_sdk.models.schemas.shopping.order import Order

--- a/rest/python/server/server_import_test.py
+++ b/rest/python/server/server_import_test.py
@@ -1,0 +1,29 @@
+#   Copyright 2026 UCP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Smoke tests for the sample server module."""
+
+import importlib
+from pathlib import Path
+import sys
+
+
+def test_server_module_imports(monkeypatch) -> None:
+  """The sample server should import with the current Python SDK models."""
+  monkeypatch.syspath_prepend(str(Path(__file__).parent))
+  sys.modules.pop("server", None)
+
+  server = importlib.import_module("server")
+
+  assert server.app is not None


### PR DESCRIPTION
## Summary
Fixes #118.

The Python Flower Shop server now imports composed extension `Checkout` models from the SDK's generated namespace paths under `dev.ucp.shopping`, matching the current python-sdk output after Universal-Commerce-Protocol/python-sdk#48.

## What changed
- Updated AP2, buyer consent, discount, and fulfillment `Checkout` imports in `rest/python/server/models.py`.
- Updated the same imports in `rest/python/server/integration_test.py`.
- Added `server_import_test.py` to smoke-test importing `server.py` with the current SDK models.

## Why
Current samples main imports `Checkout` from top-level extension packages such as `ucp_sdk.models.schemas.shopping.ap2_mandate`. After python-sdk#48, those top-level modules no longer export the composed `Checkout`; the classes live under `...dev.ucp.shopping`. Fresh setup following the README therefore fails before the server starts.

## Validation
- Reproduced the original `ImportError` before the change.
- `uv run --directory rest/python/server python - <<'PY' ... import server ... PY`
- `uv run --directory rest/python/server pytest server_import_test.py`
- `uv run --directory rest/python/server ruff format --check models.py integration_test.py server_import_test.py`
- `uv run --directory rest/python/server ruff check models.py integration_test.py server_import_test.py`
- `uv run --directory rest/python/server python -m py_compile models.py integration_test.py server_import_test.py server.py`
- Initialized the Flower Shop sample DB and verified the server starts and `GET /.well-known/ucp` returns 200 on port 8183.
- Relevant pre-commit hooks passed: `ruff`, `ruff-format`, `trailing-whitespace`, `end-of-file-fixer`, `check-added-large-files`, `detect-private-key`, `codespell`.

Note: full `uvx pre-commit run --files ...` could not complete because the Prettier hook failed while installing npm dependency `tiny-levenshtein@^1.1.0`, unrelated to these Python files.
