### PR TITLE
ci: add Python server integration-test and happy-path workflow

### DIFF
--- a/.github/workflows/python-server-tests.yml
+++ b/.github/workflows/python-server-tests.yml
@@ -89,8 +89,4 @@ jobs:
           uv sync --directory rest/python/client/flower_shop
           uv run --directory rest/python/client/flower_shop \
             simple_happy_path_client.py \
-            --server_url=http://localhost:${MERCHANT_SERVER_PORT} 2>&1 \
-            | tee client.log
-          # The client logs failures without a non-zero exit status, so
-          # assert on the explicit success marker.
-          grep -q "Happy Path completed successfully." client.log
+            --server_url=http://localhost:${MERCHANT_SERVER_PORT}

--- a/.github/workflows/python-server-tests.yml
+++ b/.github/workflows/python-server-tests.yml
@@ -17,8 +17,14 @@ name: Python Server Tests
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "rest/python/**"
+      - ".github/workflows/python-server-tests.yml"
   push:
     branches: [main]
+    paths:
+      - "rest/python/**"
+      - ".github/workflows/python-server-tests.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/python-server-tests.yml
+++ b/.github/workflows/python-server-tests.yml
@@ -1,0 +1,103 @@
+# Copyright 2026 UCP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Python Server Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  MERCHANT_SERVER_PORT: 8182
+  DATABASE_PATH: /tmp/ucp_test
+
+jobs:
+  test:
+    name: Integration tests + happy-path client (rest/python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out samples repo
+        uses: actions/checkout@v5
+        with:
+          path: samples
+
+      - name: Check out SDK repo
+        uses: actions/checkout@v5
+        with:
+          repository: Universal-Commerce-Protocol/python-sdk
+          path: python-sdk
+          # rest/python/server consumes ucp-sdk as an editable path dependency
+          # (../../../../python-sdk), so an unpinned sibling checkout breaks
+          # whenever python-sdk@main moves incompatibly — as it did on
+          # 2026-06-30 with python-sdk#48 (see samples#118). Pin to the last
+          # compatible commit and bump deliberately, together with the code
+          # changes that adopt the newer SDK.
+          ref: f54858e0cf1e8933cc0e9d89b380e2cd4a0b3f00
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync server dependencies
+        run: uv sync --directory samples/rest/python/server/
+
+      - name: Run server integration tests
+        run: uv run --directory samples/rest/python/server pytest -v
+
+      - name: Initialize test database
+        run: |
+          rm -rf ${DATABASE_PATH}
+          mkdir -p ${DATABASE_PATH}
+          uv run --directory samples/rest/python/server import_csv.py \
+            --products_db_path=${DATABASE_PATH}/products.db \
+            --transactions_db_path=${DATABASE_PATH}/transactions.db \
+            --data_dir=../test_data/flower_shop
+
+      - name: Start Flower Shop server
+        run: |
+          uv run --directory samples/rest/python/server server.py \
+            --products_db_path=${DATABASE_PATH}/products.db \
+            --transactions_db_path=${DATABASE_PATH}/transactions.db \
+            --port=${MERCHANT_SERVER_PORT} &
+          # Wait for the server to be ready
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:${MERCHANT_SERVER_PORT}/.well-known/ucp > /dev/null 2>&1; then
+              echo "Server is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Server failed to start within 30 seconds"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run happy-path client
+        run: |
+          uv sync --directory samples/rest/python/client/flower_shop
+          uv run --directory samples/rest/python/client/flower_shop \
+            simple_happy_path_client.py \
+            --server_url=http://localhost:${MERCHANT_SERVER_PORT} 2>&1 \
+            | tee client.log
+          # The client logs failures without a non-zero exit status, so
+          # assert on the explicit success marker.
+          grep -q "Happy Path completed successfully." client.log

--- a/.github/workflows/python-server-tests.yml
+++ b/.github/workflows/python-server-tests.yml
@@ -41,21 +41,6 @@ jobs:
     steps:
       - name: Check out samples repo
         uses: actions/checkout@v5
-        with:
-          path: samples
-
-      - name: Check out SDK repo
-        uses: actions/checkout@v5
-        with:
-          repository: Universal-Commerce-Protocol/python-sdk
-          path: python-sdk
-          # rest/python/server consumes ucp-sdk as an editable path dependency
-          # (../../../../python-sdk), so an unpinned sibling checkout breaks
-          # whenever python-sdk@main moves incompatibly — as it did on
-          # 2026-06-30 with python-sdk#48 (see samples#118). Pin to the last
-          # compatible commit and bump deliberately, together with the code
-          # changes that adopt the newer SDK.
-          ref: f54858e0cf1e8933cc0e9d89b380e2cd4a0b3f00
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -64,23 +49,25 @@ jobs:
         run: uv python install 3.12
 
       - name: Sync server dependencies
-        run: uv sync --directory samples/rest/python/server/
+        # ucp-sdk resolves from pip (samples#131), so this exercises the same
+        # released SDK a user installs; SDK-main drift is python-sdk CI's job.
+        run: uv sync --directory rest/python/server/
 
       - name: Run server integration tests
-        run: uv run --directory samples/rest/python/server pytest -v
+        run: uv run --directory rest/python/server pytest -v
 
       - name: Initialize test database
         run: |
           rm -rf ${DATABASE_PATH}
           mkdir -p ${DATABASE_PATH}
-          uv run --directory samples/rest/python/server import_csv.py \
+          uv run --directory rest/python/server import_csv.py \
             --products_db_path=${DATABASE_PATH}/products.db \
             --transactions_db_path=${DATABASE_PATH}/transactions.db \
             --data_dir=../test_data/flower_shop
 
       - name: Start Flower Shop server
         run: |
-          uv run --directory samples/rest/python/server server.py \
+          uv run --directory rest/python/server server.py \
             --products_db_path=${DATABASE_PATH}/products.db \
             --transactions_db_path=${DATABASE_PATH}/transactions.db \
             --port=${MERCHANT_SERVER_PORT} &
@@ -99,8 +86,8 @@ jobs:
 
       - name: Run happy-path client
         run: |
-          uv sync --directory samples/rest/python/client/flower_shop
-          uv run --directory samples/rest/python/client/flower_shop \
+          uv sync --directory rest/python/client/flower_shop
+          uv run --directory rest/python/client/flower_shop \
             simple_happy_path_client.py \
             --server_url=http://localhost:${MERCHANT_SERVER_PORT} 2>&1 \
             | tee client.log

--- a/rest/python/client/flower_shop/simple_happy_path_client.py
+++ b/rest/python/client/flower_shop/simple_happy_path_client.py
@@ -29,6 +29,7 @@ Usage:
 """
 
 import argparse
+import sys
 import json
 import logging
 from pathlib import Path
@@ -138,7 +139,7 @@ def log_interaction(
       f.write("```\n\n")
 
 
-def main() -> None:
+def main() -> int:
   """Run the happy path client."""
   parser = argparse.ArgumentParser()
 
@@ -233,7 +234,7 @@ Note:
     if response.status_code != 200:
       logger.error("Discovery failed: %s", response.text)
 
-      return
+      return 1
 
     discovery_data = response.json()
 
@@ -340,7 +341,7 @@ Note:
     if response.status_code not in [200, 201]:
       logger.error("Failed to create checkout: %s", response.text)
 
-      return
+      return 1
 
     logger.info("Successfully created checkout session: %s", checkout_id)
 
@@ -430,7 +431,7 @@ Note:
     if response.status_code != 200:
       logger.error("Failed to add items: %s", response.text)
 
-      return
+      return 1
 
     logger.info("Successfully added items.")
 
@@ -520,7 +521,7 @@ Note:
     if response.status_code != 200:
       logger.error("Failed to apply discount: %s", response.text)
 
-      return
+      return 1
 
     checkout_data = response.json()
 
@@ -719,7 +720,7 @@ Note:
         if response.status_code != 200:
           logger.error("Failed to select destination: %s", response.text)
 
-          return
+          return 1
 
         checkout_data = response.json()
 
@@ -777,7 +778,7 @@ Note:
           if response.status_code != 200:
             logger.error("Failed to select option: %s", response.text)
 
-            return
+            return 1
 
           checkout_data = response.json()
 
@@ -806,7 +807,7 @@ Note:
     if not any(h["id"] == target_handler for h in supported_handlers):
       logger.error("Merchant does not support %s. Aborting.", target_handler)
 
-      return
+      return 1
 
     # Create Payment Data (Single Instrument) using strong types
 
@@ -880,7 +881,7 @@ Note:
     if response.status_code != 200:
       logger.error("Payment failed: %s", response.text)
 
-      return
+      return 1
 
     logger.info("Payment Successful!")
 
@@ -897,13 +898,15 @@ Note:
     # ==========================================================================
 
     logger.info("\nHappy Path completed successfully.")
+    return 0
 
   except Exception:  # pylint: disable=broad-exception-caught
     logger.exception("An unexpected error occurred:")
+    return 1
 
   finally:
     client.close()
 
 
 if __name__ == "__main__":
-  main()
+  sys.exit(main())


### PR DESCRIPTION
Follow-up to #118. CI today is lint-only: nothing installs the Python server's dependencies, boots it, or runs the integration tests that already exist at `rest/python/server/integration_test.py` — so incompatibilities like #118 (the server on main cannot import against python-sdk@main since python-sdk#48) stay invisible until a newcomer follows the README and hits the ImportError.

This adds a workflow that exercises the documented paths end-to-end on every PR/push:
1. `uv sync` for `rest/python/server` (with the `python-sdk` sibling checkout the editable path dependency expects, pinned to the last compatible commit `f54858e`; the pin comment documents why and how to bump);
2. runs the existing integration tests via pytest (5 tests, currently green);
3. seeds the database from `rest/python/test_data/flower_shop` per the server README;
4. boots the server and polls `/.well-known/ucp` for readiness;
5. runs the documented happy-path client against it and asserts its explicit success marker ("Happy Path completed successfully.") — marker-based because the client logs failures without a non-zero exit status.

Had this workflow existed, it would have turned red the day python-sdk#48 merged — exactly the early signal #118 asks for.

**Verification:** full local dry-run of every step, plus the identical workflow running green in my fork: https://github.com/vishkaty/samples/actions/runs/28898090014

**Scope notes**
- No changes to `pyproject.toml` or the README here. The complementary fix for the human setup path (pinning the dependency itself, per #118) is a small follow-up I'm happy to make in whichever direction you prefer (pinned git rev vs released PyPI version).
- Covers `rest/python` only; the nodejs sample and a2a could get sibling jobs as follow-ups.