### PR TITLE
ci: build and test Node.js sample

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,59 @@
+# Copyright 2026 UCP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Node.js Build and Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rest/nodejs/**"
+      - ".github/workflows/nodejs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "rest/nodejs/**"
+      - ".github/workflows/nodejs.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: rest/nodejs
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: rest/nodejs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test --if-present


### PR DESCRIPTION
## Summary

- add a path-filtered GitHub Actions workflow for the Node.js sample
- install dependencies with Node 20 and `npm ci`
- require `npm run build` to pass
- run `npm test --if-present` so current and future Node tests are covered

## Why

The repository currently runs pre-commit checks but does not compile or test `rest/nodejs`. As a result, strict TypeScript errors in the Node.js sample remained undetected across dependency updates.

This workflow adds a focused build gate for changes under `rest/nodejs/**` without adding work to unrelated sample PRs.

## Validation

- workflow YAML parse: passed
- Prettier: passed
- codespell: passed
- exact workflow commands executed with Node 20 on the combined #123 + #125 changes:
  - `npm ci`: passed, 0 vulnerabilities
  - `npm run build`: passed
  - `npm test --if-present`: passed, 3/3 tests

## Dependencies

This draft depends on #123 and #125. The new build job is expected to fail against the current `main` branch until both existing Node.js compile failures are merged. The workflow deliberately does not use `continue-on-error`; after those dependencies land, it becomes the regression gate that prevents the same drift from recurring.
