### PR TITLE
fix(rest/python): match discount codes case-insensitively

### DIFF
--- a/rest/python/server/db.py
+++ b/rest/python/server/db.py
@@ -39,6 +39,7 @@ import uuid
 
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
+from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import JSON
 from sqlalchemy import select
@@ -288,7 +289,10 @@ async def get_discount(session: AsyncSession, code: str) -> Discount | None:
     The Discount object if found, otherwise None.
 
   """
-  return await session.get(Discount, code)
+  result = await session.execute(
+    select(Discount).where(func.upper(Discount.code) == code.upper())
+  )
+  return result.scalars().first()
 
 
 async def get_discounts_by_codes(
@@ -305,7 +309,9 @@ async def get_discounts_by_codes(
 
   """
   result = await session.execute(
-    select(Discount).where(Discount.code.in_(codes))
+    select(Discount).where(
+      func.upper(Discount.code).in_([c.upper() for c in codes])
+    )
   )
   return list(result.scalars().all())
 

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -425,6 +425,46 @@ class IntegrationTest(absltest.TestCase):
       # default validation)
       self.assertEqual(response.status_code, 422)
 
+  def test_discount_code_matches_case_insensitively(self) -> None:
+    """Codes are matched case-insensitively by business (discount.md)."""
+
+    async def seed_discount() -> None:
+      async with self.transactions_session_factory() as session:
+        await session.execute(delete(db.Discount))
+        session.add(
+          db.Discount(
+            code="10OFF", type="percentage", value=10, description="10% Off"
+          )
+        )
+        await session.commit()
+
+    asyncio.run(seed_discount())
+
+    with self.client:
+      payload = self._create_checkout_payload(
+        "test_checkout_discount_ci", [("rose", "Red Rose", 1000, 1)]
+      )
+      body = payload.model_dump(mode="json", exclude_none=True)
+      # The seeded code is 10OFF; submit it lowercase on purpose.
+      body["discounts"] = {"codes": ["10off"]}
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="dci-1", request_id="dci-1"),
+        json=body,
+      )
+      self.assertEqual(response.status_code, 201, f"Response: {response.text}")
+      data = response.json()
+      applied = (data.get("discounts") or {}).get("applied") or []
+      self.assertEqual(
+        [a["code"] for a in applied],
+        ["10OFF"],
+        "a lowercase code must match the seeded uppercase code",
+      )
+      discount_totals = [
+        t["amount"] for t in data.get("totals", []) if t["type"] == "discount"
+      ]
+      self.assertEqual(discount_totals, [100], "10% of the 1000 subtotal")
+
   def test_cancel_checkout(self) -> None:
     """Tests the checkout cancellation flow."""
     with self.client:

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -1119,10 +1119,12 @@ class CheckoutService:
       )
       # Create a map for easy lookup by code (preserving request order if
       # needed)
-      discount_map = {d.code: d for d in discounts}
+      # Codes are matched case-insensitively by business (discount.md);
+      # the applied entry echoes the canonical stored code.
+      discount_map = {d.code.upper(): d for d in discounts}
 
       for code in checkout.discounts.codes:
-        discount_obj = discount_map.get(code)
+        discount_obj = discount_map.get(code.upper())
         if discount_obj:
           discount_amount = 0
           if discount_obj.type == "percentage":
@@ -1136,7 +1138,7 @@ class CheckoutService:
               checkout.discounts.applied = []
             checkout.discounts.applied.append(
               AppliedDiscount(
-                code=code,
+                code=discount_obj.code,
                 title=discount_obj.description,
                 amount=discount_amount,
                 allocations=[


### PR DESCRIPTION
## What

`docs/specification/discount.md` (Operations → Request behavior) says:

> **Case-insensitive**: Codes are matched case-insensitively by business

The server looked codes up by exact primary key (`get_discount` → `session.get(Discount, code)`, and `get_discounts_by_codes` → `.in_(codes)`), with no normalization. The seed data is uppercase (`test_data/flower_shop/discounts.csv`: `10OFF`, `WELCOME20`, `FIXED500`), so a buyer submitting `10off` got no discount.

On the seeded flower shop (bouquet_roses, 3500), same checkout differing only in the code's case:

| submitted | `discounts.applied` | total |
|---|---|---|
| `10OFF` | `["10OFF"]` | 3150 |
| `10off` | `[]` | 3500 |

## Fix

Compare on `func.upper()` in both discount lookups; the applied entry echoes the canonical stored code. A code that is already the correct case is unaffected.

## Test

Adds an integration test that seeds `10OFF` and submits `10off`: before the fix nothing is applied; after, the discount applies (asserts `applied == ["10OFF"]` and a 10% discount total). Full `integration_test.py` stays green (6 passed), `ruff check` / `ruff format --check` clean. Verified against the last `main`-compatible python-sdk commit (`f54858e`).

## Note (separate, happy to follow up)

The spec's Response behavior also says rejected codes are communicated via `messages[]`; today an unmatched code is dropped silently. I kept this PR to the case-insensitivity fix to stay single-concern, but I'm glad to send a small follow-up adding a `messages[]` entry for rejected codes if that's welcome.
