### PR TITLE
refactor: use ucp-sdk from pip by default in python samples

### DIFF
--- a/.github/workflows/python-server-tests.yml
+++ b/.github/workflows/python-server-tests.yml
@@ -49,13 +49,12 @@ jobs:
         with:
           repository: Universal-Commerce-Protocol/python-sdk
           path: python-sdk
-          # rest/python/server consumes ucp-sdk as an editable path dependency
-          # (../../../../python-sdk), so an unpinned sibling checkout breaks
-          # whenever python-sdk@main moves incompatibly — as it did on
-          # 2026-06-30 with python-sdk#48 (see samples#118). Pin to the last
-          # compatible commit and bump deliberately, together with the code
-          # changes that adopt the newer SDK.
-          ref: f54858e0cf1e8933cc0e9d89b380e2cd4a0b3f00
+          # Track python-sdk@main. rest/python/server consumes ucp-sdk as an
+          # editable path dependency (../../../../python-sdk), so this job's
+          # purpose is to catch server-vs-SDK drift the moment it happens — a
+          # red run here is the signal to adapt the server (as samples#127 did
+          # for the SDK type-alias change), not something to pin away.
+          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/python-server-tests.yml
+++ b/.github/workflows/python-server-tests.yml
@@ -17,8 +17,14 @@ name: Python Server Tests
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "rest/python/**"
+      - ".github/workflows/python-server-tests.yml"
   push:
     branches: [main]
+    paths:
+      - "rest/python/**"
+      - ".github/workflows/python-server-tests.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/python-server-tests.yml
+++ b/.github/workflows/python-server-tests.yml
@@ -1,0 +1,103 @@
+# Copyright 2026 UCP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Python Server Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  MERCHANT_SERVER_PORT: 8182
+  DATABASE_PATH: /tmp/ucp_test
+
+jobs:
+  test:
+    name: Integration tests + happy-path client (rest/python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out samples repo
+        uses: actions/checkout@v5
+        with:
+          path: samples
+
+      - name: Check out SDK repo
+        uses: actions/checkout@v5
+        with:
+          repository: Universal-Commerce-Protocol/python-sdk
+          path: python-sdk
+          # rest/python/server consumes ucp-sdk as an editable path dependency
+          # (../../../../python-sdk), so an unpinned sibling checkout breaks
+          # whenever python-sdk@main moves incompatibly — as it did on
+          # 2026-06-30 with python-sdk#48 (see samples#118). Pin to the last
+          # compatible commit and bump deliberately, together with the code
+          # changes that adopt the newer SDK.
+          ref: f54858e0cf1e8933cc0e9d89b380e2cd4a0b3f00
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync server dependencies
+        run: uv sync --directory samples/rest/python/server/
+
+      - name: Run server integration tests
+        run: uv run --directory samples/rest/python/server pytest -v
+
+      - name: Initialize test database
+        run: |
+          rm -rf ${DATABASE_PATH}
+          mkdir -p ${DATABASE_PATH}
+          uv run --directory samples/rest/python/server import_csv.py \
+            --products_db_path=${DATABASE_PATH}/products.db \
+            --transactions_db_path=${DATABASE_PATH}/transactions.db \
+            --data_dir=../test_data/flower_shop
+
+      - name: Start Flower Shop server
+        run: |
+          uv run --directory samples/rest/python/server server.py \
+            --products_db_path=${DATABASE_PATH}/products.db \
+            --transactions_db_path=${DATABASE_PATH}/transactions.db \
+            --port=${MERCHANT_SERVER_PORT} &
+          # Wait for the server to be ready
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:${MERCHANT_SERVER_PORT}/.well-known/ucp > /dev/null 2>&1; then
+              echo "Server is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Server failed to start within 30 seconds"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run happy-path client
+        run: |
+          uv sync --directory samples/rest/python/client/flower_shop
+          uv run --directory samples/rest/python/client/flower_shop \
+            simple_happy_path_client.py \
+            --server_url=http://localhost:${MERCHANT_SERVER_PORT} 2>&1 \
+            | tee client.log
+          # The client logs failures without a non-zero exit status, so
+          # assert on the explicit success marker.
+          grep -q "Happy Path completed successfully." client.log

--- a/rest/python/client/flower_shop/README.md
+++ b/rest/python/client/flower_shop/README.md
@@ -29,7 +29,13 @@ checkout by processing a payment.
 
 ## Prerequisites
 
-1.  **Install Dependencies**: `bash uv sync`
+1.  **Install Dependencies**: `uv sync`
+
+    _Optional: If you are developing the SDK locally and want to use it, install it in editable mode:_
+
+    ```shell
+    uv pip install -e ../../../../../python-sdk
+    ```
 
 2.  **Start the Merchant Server**: You need a running UCP Merchant Server to
     execute this client against. Follow the instructions in the

--- a/rest/python/client/flower_shop/pyproject.toml
+++ b/rest/python/client/flower_shop/pyproject.toml
@@ -25,10 +25,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["."]
 
-[tool.uv.sources]
-# The relative path is stored here
-ucp-sdk = { path = "../../../../../python-sdk/", editable = true }
-
 [tool.ruff]
 line-length = 80
 indent-width = 2

--- a/rest/python/server/README.md
+++ b/rest/python/server/README.md
@@ -32,21 +32,25 @@ deployable both inside and outside of Google.
 
 ## Prepare the workspace
 
-First, clone the necessary repositories and set your environment variables. You
-will need both the Samples repository (which contains the Python server) and the
-SDK repository.
-
-NOTE: Temporarily the Samples repository expects the SDK at a known relative
-filesystem location, as such, the target paths in these example are significant.
+First, clone the Samples repository.
 
 ```shell
-git clone https://github.com/Universal-Commerce-Protocol/python-sdk.git
-pushd python-sdk
-uv sync
-popd
 git clone https://github.com/Universal-Commerce-Protocol/samples.git
 cd samples/rest/python/server
 uv sync
+```
+
+### Developing with a local SDK checkout (Optional)
+
+If you are actively developing the SDK and want to test local changes against the server, clone the SDK repository as a sibling and install it in editable mode:
+
+```shell
+# Clone SDK as sibling to samples
+git clone https://github.com/Universal-Commerce-Protocol/python-sdk.git
+
+# Install it in editable mode in the server's virtual environment
+cd samples/rest/python/server
+uv pip install -e ../../../../python-sdk
 ```
 
 ## Initialize the sample database

--- a/rest/python/server/pyproject.toml
+++ b/rest/python/server/pyproject.toml
@@ -36,10 +36,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["."]
 
-[tool.uv.sources]
-# The relative path is stored here
-ucp-sdk = { path = "../../../../python-sdk/", editable = true }
-
 [tool.ruff]
 line-length = 80
 indent-width = 2


### PR DESCRIPTION
# Description

This PR updates the Python samples to use the published `ucp-sdk` from PyPI by default, rather than expecting a local checkout of `python-sdk` at a relative path.

It also updates the GHA workflow to manually install the local SDK checkout to retain drift detection, and updates READMEs to document optional local SDK development.

## Category (Required)

- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities.
- [x] **Infrastructure**: CI/CD, Linters, or build scripts.
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite.


## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

---

