### PR TITLE
refactor: use ucp-sdk from pip by default in python samples

### DIFF
--- a/rest/python/client/flower_shop/README.md
+++ b/rest/python/client/flower_shop/README.md
@@ -29,7 +29,13 @@ checkout by processing a payment.
 
 ## Prerequisites
 
-1.  **Install Dependencies**: `bash uv sync`
+1.  **Install Dependencies**: `uv sync`
+
+    _Optional: If you are developing the SDK locally and want to use it, install it in editable mode:_
+
+    ```shell
+    uv pip install -e ../../../../../python-sdk
+    ```
 
 2.  **Start the Merchant Server**: You need a running UCP Merchant Server to
     execute this client against. Follow the instructions in the

--- a/rest/python/client/flower_shop/pyproject.toml
+++ b/rest/python/client/flower_shop/pyproject.toml
@@ -25,10 +25,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["."]
 
-[tool.uv.sources]
-# The relative path is stored here
-ucp-sdk = { path = "../../../../../python-sdk/", editable = true }
-
 [tool.ruff]
 line-length = 80
 indent-width = 2

--- a/rest/python/server/README.md
+++ b/rest/python/server/README.md
@@ -32,21 +32,25 @@ deployable both inside and outside of Google.
 
 ## Prepare the workspace
 
-First, clone the necessary repositories and set your environment variables. You
-will need both the Samples repository (which contains the Python server) and the
-SDK repository.
-
-NOTE: Temporarily the Samples repository expects the SDK at a known relative
-filesystem location, as such, the target paths in these example are significant.
+First, clone the Samples repository.
 
 ```shell
-git clone https://github.com/Universal-Commerce-Protocol/python-sdk.git
-pushd python-sdk
-uv sync
-popd
 git clone https://github.com/Universal-Commerce-Protocol/samples.git
 cd samples/rest/python/server
 uv sync
+```
+
+### Developing with a local SDK checkout (Optional)
+
+If you are actively developing the SDK and want to test local changes against the server, clone the SDK repository as a sibling and install it in editable mode:
+
+```shell
+# Clone SDK as sibling to samples
+git clone https://github.com/Universal-Commerce-Protocol/python-sdk.git
+
+# Install it in editable mode in the server's virtual environment
+cd samples/rest/python/server
+uv pip install -e ../../../../python-sdk
 ```
 
 ## Initialize the sample database

--- a/rest/python/server/pyproject.toml
+++ b/rest/python/server/pyproject.toml
@@ -36,10 +36,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["."]
 
-[tool.uv.sources]
-# The relative path is stored here
-ucp-sdk = { path = "../../../../python-sdk/", editable = true }
-
 [tool.ruff]
 line-length = 80
 indent-width = 2


### PR DESCRIPTION
# Description

This PR updates the Python samples to use the published `ucp-sdk` from PyPI by default, rather than expecting a local checkout of `python-sdk` at a relative path.

It also updates READMEs to document optional local SDK development.

## Category (Required)

- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities.
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite.

## Related Issues

None

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

---