### PR TITLE
fix: correct UCP version data format in samples

### DIFF
--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -96,7 +96,7 @@ async def validate_ucp_headers(ucp_agent: str):
 
   if agent_date > server_date:
     raise HTTPException(
-      status_code=400,
+      status_code=422,
       detail=UcpErrorDetail(
         errors=[
           UcpErrorDetailItem(

--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -73,7 +73,10 @@ async def validate_ucp_headers(ucp_agent: str):
   try:
     server_date = parse_ucp_version(server_version)
   except UcpVersionError as exc:
-    raise HTTPException(status_code=500, detail=exc.to_detail().model_dump()) from exc
+    raise HTTPException(
+      status_code=500,
+      detail=exc.to_detail().model_dump(),
+    ) from exc
 
   # Default to server version if UCP-Agent omits version=.
   agent_version = server_version
@@ -92,7 +95,10 @@ async def validate_ucp_headers(ucp_agent: str):
     try:
       agent_date = parse_ucp_version(agent_version)
     except UcpVersionError as exc:
-      raise HTTPException(status_code=400, detail=exc.to_detail().model_dump()) from exc
+      raise HTTPException(
+        status_code=400,
+        detail=exc.to_detail().model_dump(),
+      ) from exc
 
   if agent_date > server_date:
     raise HTTPException(

--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -28,6 +28,7 @@ from typing import Annotated
 
 import config
 import db
+from exceptions import UcpVersionError
 from fastapi import Depends
 from fastapi import Header
 from fastapi import HTTPException
@@ -36,6 +37,7 @@ from pydantic import BaseModel
 from services.checkout_service import CheckoutService
 from services.fulfillment_service import FulfillmentService
 from sqlalchemy.ext.asyncio import AsyncSession
+from ucp_version import parse_ucp_version
 
 
 class CommonHeaders(BaseModel):
@@ -63,39 +65,61 @@ async def common_headers(
   )
 
 
+def _version_error_detail(code: str, message: str) -> dict:
+  """Build a UCP-shaped error detail payload for version failures."""
+  return {
+    "status": "error",
+    "errors": [
+      {
+        "code": code,
+        "message": message,
+        "severity": "critical",
+      }
+    ],
+  }
+
+
 async def validate_ucp_headers(ucp_agent: str):
   """Validate UCP headers and version negotiation."""
   server_version = config.get_server_version()
-  agent_version = server_version  # Default to server version if not specified
+  try:
+    server_date = parse_ucp_version(server_version)
+  except UcpVersionError as exc:
+    raise HTTPException(
+      status_code=500, detail=exc.to_detail()
+    ) from exc
+
+  # Default to server version if UCP-Agent omits version=.
+  agent_version = server_version
+  agent_date = server_date
 
   # Use regex to extract version more robustly.
   # We look for 'version=' either at the start or after a semicolon,
   # allowing for whitespace.
-  # Matches: version="1.2.3" or version=1.2.3
+  # Matches: version="2026-01-23" or version=2026-01-23
   match = re.search(
     r"(?:^|;)\s*version=(?:\"([^\"]+)\"|([^;]+))", ucp_agent, re.IGNORECASE
   )
   if match:
     # Group 1 is quoted value, Group 2 is unquoted value
-    agent_version = match.group(1) or match.group(2)
-    agent_version = agent_version.strip()
+    agent_version = (match.group(1) or match.group(2)).strip()
+    try:
+      agent_date = parse_ucp_version(agent_version)
+    except UcpVersionError as exc:
+      raise HTTPException(
+        status_code=400, detail=exc.to_detail()
+      ) from exc
 
-  if agent_version > server_version:
+  if agent_date > server_date:
     raise HTTPException(
       status_code=400,
-      detail={
-        "status": "error",
-        "errors": [
-          {
-            "code": "VERSION_UNSUPPORTED",
-            "message": (
-              f"Version {agent_version} is not supported. This merchant"
-              f" implements version {server_version}."
-            ),
-            "severity": "critical",
-          }
-        ],
-      },
+      detail=_version_error_detail(
+        "VERSION_UNSUPPORTED",
+        (
+          f"Version {agent_version} is not supported. This merchant"
+          f" implements version {server_version}."
+        ),
+      ),
     )
 
 

--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -28,6 +28,8 @@ from typing import Annotated
 
 import config
 import db
+from exceptions import UcpErrorDetail
+from exceptions import UcpErrorDetailItem
 from exceptions import UcpVersionError
 from fastapi import Depends
 from fastapi import Header
@@ -65,27 +67,13 @@ async def common_headers(
   )
 
 
-def _version_error_detail(code: str, message: str) -> dict:
-  """Build a UCP-shaped error detail payload for version failures."""
-  return {
-    "status": "error",
-    "errors": [
-      {
-        "code": code,
-        "message": message,
-        "severity": "critical",
-      }
-    ],
-  }
-
-
 async def validate_ucp_headers(ucp_agent: str):
   """Validate UCP headers and version negotiation."""
   server_version = config.get_server_version()
   try:
     server_date = parse_ucp_version(server_version)
   except UcpVersionError as exc:
-    raise HTTPException(status_code=500, detail=exc.to_detail()) from exc
+    raise HTTPException(status_code=500, detail=exc.to_detail().model_dump()) from exc
 
   # Default to server version if UCP-Agent omits version=.
   agent_version = server_version
@@ -104,18 +92,23 @@ async def validate_ucp_headers(ucp_agent: str):
     try:
       agent_date = parse_ucp_version(agent_version)
     except UcpVersionError as exc:
-      raise HTTPException(status_code=400, detail=exc.to_detail()) from exc
+      raise HTTPException(status_code=400, detail=exc.to_detail().model_dump()) from exc
 
   if agent_date > server_date:
     raise HTTPException(
       status_code=400,
-      detail=_version_error_detail(
-        "VERSION_UNSUPPORTED",
-        (
-          f"Version {agent_version} is not supported. This merchant"
-          f" implements version {server_version}."
-        ),
-      ),
+      detail=UcpErrorDetail(
+        errors=[
+          UcpErrorDetailItem(
+            code="VERSION_UNSUPPORTED",
+            message=(
+              f"Version {agent_version} is not supported. This merchant"
+              f" implements version {server_version}."
+            ),
+            severity="critical",
+          )
+        ]
+      ).model_dump(),
     )
 
 

--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -85,9 +85,7 @@ async def validate_ucp_headers(ucp_agent: str):
   try:
     server_date = parse_ucp_version(server_version)
   except UcpVersionError as exc:
-    raise HTTPException(
-      status_code=500, detail=exc.to_detail()
-    ) from exc
+    raise HTTPException(status_code=500, detail=exc.to_detail()) from exc
 
   # Default to server version if UCP-Agent omits version=.
   agent_version = server_version
@@ -106,9 +104,7 @@ async def validate_ucp_headers(ucp_agent: str):
     try:
       agent_date = parse_ucp_version(agent_version)
     except UcpVersionError as exc:
-      raise HTTPException(
-        status_code=400, detail=exc.to_detail()
-      ) from exc
+      raise HTTPException(status_code=400, detail=exc.to_detail()) from exc
 
   if agent_date > server_date:
     raise HTTPException(

--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -15,6 +15,19 @@
 """Custom exceptions for the UCP Merchant Server."""
 
 
+from pydantic import BaseModel
+
+class UcpErrorDetailItem(BaseModel):
+  code: str
+  message: str
+  severity: str = "critical"
+
+
+class UcpErrorDetail(BaseModel):
+  status: str = "error"
+  errors: list[UcpErrorDetailItem]
+
+
 class UcpError(Exception):
   """Base class for all UCP exceptions."""
 
@@ -85,15 +98,15 @@ class UcpVersionError(UcpError):
     """Initialize UcpVersionError."""
     super().__init__(message, code=code, status_code=400)
 
-  def to_detail(self) -> dict:
+  def to_detail(self) -> UcpErrorDetail:
     """Return an error payload matching UCP REST error shape."""
-    return {
-      "status": "error",
-      "errors": [
-        {
-          "code": self.code,
-          "message": self.message,
-          "severity": "critical",
-        }
-      ],
-    }
+    return UcpErrorDetail(
+      errors=[
+        UcpErrorDetailItem(
+          code=self.code,
+          message=self.message,
+          severity="critical",
+        )
+      ]
+    )
+

--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -14,16 +14,20 @@
 
 """Custom exceptions for the UCP Merchant Server."""
 
-
 from pydantic import BaseModel
 
+
 class UcpErrorDetailItem(BaseModel):
+  """Details of a single error."""
+
   code: str
   message: str
   severity: str = "critical"
 
 
 class UcpErrorDetail(BaseModel):
+  """Top-level error response payload."""
+
   status: str = "error"
   errors: list[UcpErrorDetailItem]
 
@@ -109,4 +113,3 @@ class UcpVersionError(UcpError):
         )
       ]
     )
-

--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -76,3 +76,26 @@ class InvalidRequestError(UcpError):
   def __init__(self, message: str):
     """Initialize InvalidRequestError."""
     super().__init__(message, code="INVALID_REQUEST", status_code=400)
+
+
+class UcpVersionError(UcpError):
+  """Raised when a UCP version string is invalid or unsupported."""
+
+  def __init__(
+    self, message: str, code: str = "VERSION_INVALID_FORMAT"
+  ):
+    """Initialize UcpVersionError."""
+    super().__init__(message, code=code, status_code=400)
+
+  def to_detail(self) -> dict:
+    """Return an error payload matching UCP REST error shape."""
+    return {
+      "status": "error",
+      "errors": [
+        {
+          "code": self.code,
+          "message": self.message,
+          "severity": "critical",
+        }
+      ],
+    }

--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -81,9 +81,7 @@ class InvalidRequestError(UcpError):
 class UcpVersionError(UcpError):
   """Raised when a UCP version string is invalid or unsupported."""
 
-  def __init__(
-    self, message: str, code: str = "VERSION_INVALID_FORMAT"
-  ):
+  def __init__(self, message: str, code: str = "VERSION_INVALID_FORMAT"):
     """Initialize UcpVersionError."""
     super().__init__(message, code=code, status_code=400)
 

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -496,6 +496,62 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(response.status_code, 409)
       self.assertIn("Cannot cancel checkout", response.json()["detail"])
 
+  def test_version_invalid_format(self) -> None:
+    """Tests that UCP-Agent with invalid version format is rejected."""
+    with self.client:
+      payload = self._create_checkout_payload(
+        "test_version_invalid", [("rose", "Red Rose", 1000, 1)]
+      )
+      headers = self._get_headers(
+        idempotency_key="ver_1", request_id="ver_1"
+      )
+      headers["UCP-Agent"] = (
+        'profile="https://agent.example/profile"; version="bad-version"'
+      )
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=headers,
+        json=payload.model_dump(mode="json", exclude_none=True),
+      )
+      self.assertEqual(response.status_code, 400)
+
+      # Verify the error structure matches UcpErrorDetail
+      data = response.json()
+      self.assertIn("detail", data)
+      detail = data["detail"]
+      self.assertEqual(detail["status"], "error")
+      self.assertEqual(len(detail["errors"]), 1)
+      self.assertEqual(detail["errors"][0]["code"], "VERSION_INVALID_FORMAT")
+      self.assertEqual(detail["errors"][0]["severity"], "critical")
+
+  def test_version_unsupported(self) -> None:
+    """Tests that UCP-Agent with unsupported (newer) version is rejected."""
+    with self.client:
+      payload = self._create_checkout_payload(
+        "test_version_unsupported", [("rose", "Red Rose", 1000, 1)]
+      )
+      headers = self._get_headers(
+        idempotency_key="ver_2", request_id="ver_2"
+      )
+      # Server version is 2026-04-08, so 2026-04-09 should be unsupported
+      headers["UCP-Agent"] = (
+        'profile="https://agent.example/profile"; version="2026-04-09"'
+      )
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=headers,
+        json=payload.model_dump(mode="json", exclude_none=True),
+      )
+      self.assertEqual(response.status_code, 400)
+
+      # Verify the error structure matches UcpErrorDetail
+      data = response.json()
+      self.assertIn("detail", data)
+      detail = data["detail"]
+      self.assertEqual(detail["status"], "error")
+      self.assertEqual(len(detail["errors"]), 1)
+      self.assertEqual(detail["errors"][0]["code"], "VERSION_UNSUPPORTED")
+      self.assertEqual(detail["errors"][0]["severity"], "critical")
 
 if __name__ == "__main__":
   absltest.main()

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -502,9 +502,7 @@ class IntegrationTest(absltest.TestCase):
       payload = self._create_checkout_payload(
         "test_version_invalid", [("rose", "Red Rose", 1000, 1)]
       )
-      headers = self._get_headers(
-        idempotency_key="ver_1", request_id="ver_1"
-      )
+      headers = self._get_headers(idempotency_key="ver_1", request_id="ver_1")
       headers["UCP-Agent"] = (
         'profile="https://agent.example/profile"; version="bad-version"'
       )
@@ -530,9 +528,7 @@ class IntegrationTest(absltest.TestCase):
       payload = self._create_checkout_payload(
         "test_version_unsupported", [("rose", "Red Rose", 1000, 1)]
       )
-      headers = self._get_headers(
-        idempotency_key="ver_2", request_id="ver_2"
-      )
+      headers = self._get_headers(idempotency_key="ver_2", request_id="ver_2")
       # Server version is 2026-04-08, so 2026-04-09 should be unsupported
       headers["UCP-Agent"] = (
         'profile="https://agent.example/profile"; version="2026-04-09"'
@@ -552,6 +548,7 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(len(detail["errors"]), 1)
       self.assertEqual(detail["errors"][0]["code"], "VERSION_UNSUPPORTED")
       self.assertEqual(detail["errors"][0]["severity"], "critical")
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -542,7 +542,7 @@ class IntegrationTest(absltest.TestCase):
         headers=headers,
         json=payload.model_dump(mode="json", exclude_none=True),
       )
-      self.assertEqual(response.status_code, 400)
+      self.assertEqual(response.status_code, 422)
 
       # Verify the error structure matches UcpErrorDetail
       data = response.json()

--- a/rest/python/server/ucp_version.py
+++ b/rest/python/server/ucp_version.py
@@ -32,14 +32,10 @@ def parse_ucp_version(version: str) -> datetime.date:
     A datetime.date representing the version.
 
   Raises:
-    TypeError: If version is not a string.
     UcpVersionError: If the string is not a valid YYYY-MM-DD calendar date.
     No provision for other formats supported like YYYY-MM-DDTHH:MM:SSZ
 
   """
-  if not isinstance(version, str):
-    raise TypeError(f"Version must be a string, got {type(version).__name__}.")
-
   version = version.strip()
   if not _UCP_VERSION_RE.fullmatch(version):
     raise UcpVersionError(

--- a/rest/python/server/ucp_version.py
+++ b/rest/python/server/ucp_version.py
@@ -35,6 +35,7 @@ def parse_ucp_version(version: str) -> datetime.date:
     TypeError: If version is not a string.
     UcpVersionError: If the string is not a valid YYYY-MM-DD calendar date.
     No provision for other formats supported like YYYY-MM-DDTHH:MM:SSZ
+
   """
   if not isinstance(version, str):
     raise TypeError(f"Version must be a string, got {type(version).__name__}.")

--- a/rest/python/server/ucp_version.py
+++ b/rest/python/server/ucp_version.py
@@ -1,0 +1,54 @@
+#   Copyright 2026 UCP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""UCP version string parsing (YYYY-MM-DD)."""
+
+import datetime
+import re
+
+from exceptions import UcpVersionError
+
+_UCP_VERSION_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def parse_ucp_version(version: str) -> datetime.date:
+  """Parse a UCP version string in YYYY-MM-DD format.
+
+  Args:
+    version: The version string to parse.
+
+  Returns:
+    A datetime.date representing the version.
+
+  Raises:
+    TypeError: If version is not a string.
+    UcpVersionError: If the string is not a valid YYYY-MM-DD calendar date.
+  """
+  if not isinstance(version, str):
+    raise TypeError(f"Version must be a string, got {type(version).__name__}.")
+
+  version = version.strip()
+  if not _UCP_VERSION_RE.fullmatch(version):
+    raise UcpVersionError(
+      f"Version '{version}' is invalid. Expected YYYY-MM-DD.",
+      code="VERSION_INVALID_FORMAT",
+    )
+
+  try:
+    return datetime.date.fromisoformat(version)
+  except ValueError as exc:
+    raise UcpVersionError(
+      f"Version '{version}' is invalid. Expected YYYY-MM-DD.",
+      code="VERSION_INVALID_FORMAT",
+    ) from exc

--- a/rest/python/server/ucp_version.py
+++ b/rest/python/server/ucp_version.py
@@ -34,7 +34,7 @@ def parse_ucp_version(version: str) -> datetime.date:
   Raises:
     TypeError: If version is not a string.
     UcpVersionError: If the string is not a valid YYYY-MM-DD calendar date.
-
+    No provision for other formats supported like YYYY-MM-DDTHH:MM:SSZ
   """
   if not isinstance(version, str):
     raise TypeError(f"Version must be a string, got {type(version).__name__}.")

--- a/rest/python/server/ucp_version.py
+++ b/rest/python/server/ucp_version.py
@@ -34,6 +34,7 @@ def parse_ucp_version(version: str) -> datetime.date:
   Raises:
     TypeError: If version is not a string.
     UcpVersionError: If the string is not a valid YYYY-MM-DD calendar date.
+
   """
   if not isinstance(version, str):
     raise TypeError(f"Version must be a string, got {type(version).__name__}.")

--- a/rest/python/server/ucp_version_test.py
+++ b/rest/python/server/ucp_version_test.py
@@ -1,3 +1,17 @@
+#   Copyright 2026 UCP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 """Unit tests for UCP version parsing."""
 
 import datetime
@@ -11,28 +25,34 @@ class UcpVersionTest(unittest.TestCase):
   """Tests parse_ucp_version behavior."""
 
   def test_parse_valid_date(self) -> None:
+    """Test parsing a valid YYYY-MM-DD date."""
     parsed = parse_ucp_version("2026-01-23")
     self.assertEqual(parsed, datetime.date(2026, 1, 23))
 
   def test_parse_strips_whitespace(self) -> None:
+    """Test that leading/trailing whitespace is stripped before parsing."""
     parsed = parse_ucp_version(" 2026-01-23 ")
     self.assertEqual(parsed, datetime.date(2026, 1, 23))
 
   def test_parse_rejects_non_string(self) -> None:
+    """Test that non-string inputs raise TypeError."""
     with self.assertRaises(TypeError):
       parse_ucp_version(123)  # type: ignore[arg-type]
 
   def test_parse_rejects_invalid_format(self) -> None:
+    """Test that invalid formats raise UcpVersionError."""
     with self.assertRaises(UcpVersionError) as exc:
       parse_ucp_version("2026/01/23")
     self.assertEqual(exc.exception.code, "VERSION_INVALID_FORMAT")
 
   def test_parse_rejects_invalid_calendar_date(self) -> None:
+    """Test that invalid calendar dates (e.g. Feb 30) raise UcpVersionError."""
     with self.assertRaises(UcpVersionError) as exc:
       parse_ucp_version("2026-02-30")
     self.assertEqual(exc.exception.code, "VERSION_INVALID_FORMAT")
 
   def test_parse_rejects_datetime_format(self) -> None:
+    """Test that datetime formats (with time component) are rejected."""
     with self.assertRaises(UcpVersionError) as exc:
       parse_ucp_version("2026-01-23T10:11:12Z")
     self.assertEqual(exc.exception.code, "VERSION_INVALID_FORMAT")

--- a/rest/python/server/ucp_version_test.py
+++ b/rest/python/server/ucp_version_test.py
@@ -1,0 +1,42 @@
+"""Unit tests for UCP version parsing."""
+
+import datetime
+import unittest
+
+from exceptions import UcpVersionError
+from ucp_version import parse_ucp_version
+
+
+class UcpVersionTest(unittest.TestCase):
+  """Tests parse_ucp_version behavior."""
+
+  def test_parse_valid_date(self) -> None:
+    parsed = parse_ucp_version("2026-01-23")
+    self.assertEqual(parsed, datetime.date(2026, 1, 23))
+
+  def test_parse_strips_whitespace(self) -> None:
+    parsed = parse_ucp_version(" 2026-01-23 ")
+    self.assertEqual(parsed, datetime.date(2026, 1, 23))
+
+  def test_parse_rejects_non_string(self) -> None:
+    with self.assertRaises(TypeError):
+      parse_ucp_version(123)  # type: ignore[arg-type]
+
+  def test_parse_rejects_invalid_format(self) -> None:
+    with self.assertRaises(UcpVersionError) as exc:
+      parse_ucp_version("2026/01/23")
+    self.assertEqual(exc.exception.code, "VERSION_INVALID_FORMAT")
+
+  def test_parse_rejects_invalid_calendar_date(self) -> None:
+    with self.assertRaises(UcpVersionError) as exc:
+      parse_ucp_version("2026-02-30")
+    self.assertEqual(exc.exception.code, "VERSION_INVALID_FORMAT")
+
+  def test_parse_rejects_datetime_format(self) -> None:
+    with self.assertRaises(UcpVersionError) as exc:
+      parse_ucp_version("2026-01-23T10:11:12Z")
+    self.assertEqual(exc.exception.code, "VERSION_INVALID_FORMAT")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/rest/python/server/ucp_version_test.py
+++ b/rest/python/server/ucp_version_test.py
@@ -34,11 +34,6 @@ class UcpVersionTest(unittest.TestCase):
     parsed = parse_ucp_version(" 2026-01-23 ")
     self.assertEqual(parsed, datetime.date(2026, 1, 23))
 
-  def test_parse_rejects_non_string(self) -> None:
-    """Test that non-string inputs raise TypeError."""
-    with self.assertRaises(TypeError):
-      parse_ucp_version(123)  # type: ignore[arg-type]
-
   def test_parse_rejects_invalid_format(self) -> None:
     """Test that invalid formats raise UcpVersionError."""
     with self.assertRaises(UcpVersionError) as exc:


### PR DESCRIPTION
﻿# Description

Fix UCP version in the Python REST merchant sample (rest/python/server).

validate_ucp_headers previously compared agent and merchant versions with string ordering (agent_version > server_version), which is incorrect for UCP YYYY-MM-DD versions. In discovery_profile.json looks like it is in date format, for example:
 "version": "2026-01-23"

This change parses versions as ISO calendar dates, compares datetime.date values, returns VERSION_INVALID_FORMAT (400) for malformed agent versions, and returns VERSION_UNSUPPORTED (400) when the agent version is newer than the merchant. Behavior is unchanged when UCP-Agent omits version= (defaults to merchant version).

Files changed: ucp_version.py (new), exceptions.py (UcpVersionError), dependencies.py (date-based validation).
Note: the tests are not added, can add the tests if instructed to add them at a new tests folder.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [X] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

<!-- Link to any related issues here. e.g., "Fixes #123" -->

## Checklist

- [X] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [ ] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Example response for a newer agent version (version="2027-01-01" vs merchant 2026-01-23):

{
  "detail": {
    "status": "error",
    "errors": [{
      "code": "VERSION_UNSUPPORTED",
      "message": "Version 2027-01-01 is not supported. This merchant implements version 2026-01-23.",
      "severity": "critical"
    }]
  }
}
