### PR TITLE
fix(rest/python): return 422 for version_unsupported

### DIFF
--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -82,7 +82,8 @@ async def validate_ucp_headers(ucp_agent: str):
 
   if agent_version > server_version:
     raise HTTPException(
-      status_code=400,
+      # version_unsupported maps to REST 422 in the overview.md error registry.
+      status_code=422,
       detail={
         "status": "error",
         "errors": [

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -425,6 +425,29 @@ class IntegrationTest(absltest.TestCase):
       # default validation)
       self.assertEqual(response.status_code, 422)
 
+  def test_unsupported_version_returns_422(self) -> None:
+    """A future protocol version is rejected with 422 version_unsupported.
+
+    The error registry in overview.md maps `version_unsupported` to REST 422.
+    """
+    with self.client:
+      payload = self._create_checkout_payload(
+        "test_checkout_bad_version", [("rose", "Red Rose", 1000, 1)]
+      )
+      headers = self._get_headers(idempotency_key="ver", request_id="ver")
+      headers["UCP-Agent"] = (
+        'profile="https://agent.example/profile"; version="2999-01-01"'
+      )
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=headers,
+        json=payload.model_dump(mode="json", exclude_none=True),
+      )
+      self.assertEqual(response.status_code, 422, f"Response: {response.text}")
+      # It is the structured negotiation error, not a generic validation 422.
+      error = response.json()["detail"]["errors"][0]
+      self.assertEqual(error["severity"], "critical")
+
   def test_discount_code_matches_case_insensitively(self) -> None:
     """Codes are matched case-insensitively by business (discount.md)."""
 


### PR DESCRIPTION
## What

The version-negotiation check in `rest/python/server/dependencies.py` raised
HTTP **400** when a platform requests a newer protocol version than the server
supports. The error registry in `docs/specification/overview.md` maps
`version_unsupported` to REST **422**. This returns 422.

## Why

422 lets a platform distinguish a protocol-negotiation failure (retry with an
older version / re-discover) from a generic 400 malformed request. The structured
error body (`detail.errors[].code`, `severity: critical`) is unchanged.

## Test

Adds `test_unsupported_version_returns_422`: a future `UCP-Agent` version
(`version="2999-01-01"`) now yields 422 with the negotiation error. It fails on
the old 400 and passes on the fix. Full suite green (8 passed), pre-commit clean.

## Note (not changed here)

The registry also lists the code as lowercase `version_unsupported`, while the
server (and the a2a `business_agent` resolver) emit `VERSION_UNSUPPORTED`. Since
the casing is shared across both reference implementations, I left it untouched
to avoid an inconsistent partial change — happy to align both if you'd like it in
a follow-up.
