### PR TITLE
fix: trim discovery transports and return 422 on version mismatch

### DIFF
--- a/rest/nodejs/src/index.ts
+++ b/rest/nodejs/src/index.ts
@@ -63,8 +63,21 @@ app.use(async (c: Context, next: () => Promise<void>) => {
       // Ideally we'd parse and check compatibility.
       if (clientVersion > serverVersion) {
         return c.json(
-          { error: `Unsupported UCP version: ${clientVersion}` },
-          400
+          {
+            ucp: {
+              version: serverVersion,
+              status: "error",
+            },
+            messages: [
+              {
+                type: "error",
+                code: "VERSION_UNSUPPORTED",
+                content: `Version ${clientVersion} is not supported. This merchant implements version ${serverVersion}.`,
+                severity: "unrecoverable",
+              },
+            ],
+          },
+          422
         );
       }
     }

--- a/rest/python/server/dependencies.py
+++ b/rest/python/server/dependencies.py
@@ -28,8 +28,7 @@ from typing import Annotated
 
 import config
 import db
-from exceptions import UcpErrorDetail
-from exceptions import UcpErrorDetailItem
+from exceptions import UcpError
 from exceptions import UcpVersionError
 from fastapi import Depends
 from fastapi import Header
@@ -73,10 +72,7 @@ async def validate_ucp_headers(ucp_agent: str):
   try:
     server_date = parse_ucp_version(server_version)
   except UcpVersionError as exc:
-    raise HTTPException(
-      status_code=500,
-      detail=exc.to_detail().model_dump(),
-    ) from exc
+    raise UcpError("Server version configuration is invalid") from exc
 
   # Default to server version if UCP-Agent omits version=.
   agent_version = server_version
@@ -92,29 +88,16 @@ async def validate_ucp_headers(ucp_agent: str):
   if match:
     # Group 1 is quoted value, Group 2 is unquoted value
     agent_version = (match.group(1) or match.group(2)).strip()
-    try:
-      agent_date = parse_ucp_version(agent_version)
-    except UcpVersionError as exc:
-      raise HTTPException(
-        status_code=400,
-        detail=exc.to_detail().model_dump(),
-      ) from exc
+    agent_date = parse_ucp_version(agent_version)
 
   if agent_date > server_date:
-    raise HTTPException(
+    raise UcpVersionError(
+      message=(
+        f"Version {agent_version} is not supported. This merchant"
+        f" implements version {server_version}."
+      ),
+      code="VERSION_UNSUPPORTED",
       status_code=422,
-      detail=UcpErrorDetail(
-        errors=[
-          UcpErrorDetailItem(
-            code="VERSION_UNSUPPORTED",
-            message=(
-              f"Version {agent_version} is not supported. This merchant"
-              f" implements version {server_version}."
-            ),
-            severity="critical",
-          )
-        ]
-      ).model_dump(),
     )
 
 

--- a/rest/python/server/enums.py
+++ b/rest/python/server/enums.py
@@ -36,3 +36,20 @@ class OrderStatus(str, enum.Enum):
   """Possible states for an order."""
 
   PROCESSING = "processing"
+
+
+class MessageType(str, enum.Enum):
+  """Type of message in UCP response."""
+
+  ERROR = "error"
+  WARNING = "warning"
+  INFO = "info"
+
+
+class ErrorSeverity(str, enum.Enum):
+  """Severity levels for UCP error messages."""
+
+  RECOVERABLE = "recoverable"
+  REQUIRES_BUYER_INPUT = "requires_buyer_input"
+  REQUIRES_BUYER_REVIEW = "requires_buyer_review"
+  UNRECOVERABLE = "unrecoverable"

--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -16,14 +16,16 @@
 
 from pydantic import BaseModel
 
+from enums import ErrorSeverity, MessageType
+
 
 class UcpMessageError(BaseModel):
   """Details of a single error, matching message_error.json schema."""
 
-  type: str = "error"
+  type: MessageType = MessageType.ERROR
   code: str
   content: str
-  severity: str
+  severity: ErrorSeverity
 
 
 class UcpErrorResponse(BaseModel):
@@ -41,7 +43,7 @@ class UcpError(Exception):
     message: str,
     code: str = "INTERNAL_ERROR",
     status_code: int = 500,
-    severity: str = "unrecoverable",
+    severity: ErrorSeverity = ErrorSeverity.UNRECOVERABLE,
   ):
     """Initialize UcpError."""
     self.message = message
@@ -60,7 +62,7 @@ class ResourceNotFoundError(UcpError):
       message,
       code="RESOURCE_NOT_FOUND",
       status_code=404,
-      severity="unrecoverable",
+      severity=ErrorSeverity.UNRECOVERABLE,
     )
 
 
@@ -73,7 +75,7 @@ class IdempotencyConflictError(UcpError):
       message,
       code="IDEMPOTENCY_CONFLICT",
       status_code=409,
-      severity="unrecoverable",
+      severity=ErrorSeverity.UNRECOVERABLE,
     )
 
 
@@ -86,7 +88,7 @@ class CheckoutNotModifiableError(UcpError):
       message,
       code="CHECKOUT_NOT_MODIFIABLE",
       status_code=409,
-      severity="unrecoverable",
+      severity=ErrorSeverity.UNRECOVERABLE,
     )
 
 
@@ -99,7 +101,7 @@ class OutOfStockError(UcpError):
       message,
       code="OUT_OF_STOCK",
       status_code=status_code,
-      severity="unrecoverable",
+      severity=ErrorSeverity.UNRECOVERABLE,
     )
 
 
@@ -117,7 +119,7 @@ class PaymentFailedError(UcpError):
       message,
       code=code,
       status_code=status_code,
-      severity="requires_buyer_input",
+      severity=ErrorSeverity.REQUIRES_BUYER_INPUT,
     )
 
 
@@ -130,7 +132,7 @@ class InvalidRequestError(UcpError):
       message,
       code="INVALID_REQUEST",
       status_code=400,
-      severity="unrecoverable",
+      severity=ErrorSeverity.UNRECOVERABLE,
     )
 
 
@@ -142,7 +144,7 @@ class UcpVersionError(UcpError):
     message: str,
     code: str = "VERSION_INVALID_FORMAT",
     status_code: int = 400,
-    severity: str = "unrecoverable",
+    severity: ErrorSeverity = ErrorSeverity.UNRECOVERABLE,
   ):
     """Initialize UcpVersionError."""
     super().__init__(

--- a/rest/python/server/exceptions.py
+++ b/rest/python/server/exceptions.py
@@ -17,31 +17,37 @@
 from pydantic import BaseModel
 
 
-class UcpErrorDetailItem(BaseModel):
-  """Details of a single error."""
+class UcpMessageError(BaseModel):
+  """Details of a single error, matching message_error.json schema."""
 
+  type: str = "error"
   code: str
-  message: str
-  severity: str = "critical"
+  content: str
+  severity: str
 
 
-class UcpErrorDetail(BaseModel):
-  """Top-level error response payload."""
+class UcpErrorResponse(BaseModel):
+  """Top-level error response payload, matching error_response.json schema."""
 
-  status: str = "error"
-  errors: list[UcpErrorDetailItem]
+  ucp: dict  # Will contain {"version": ..., "status": "error"}
+  messages: list[UcpMessageError]
 
 
 class UcpError(Exception):
   """Base class for all UCP exceptions."""
 
   def __init__(
-    self, message: str, code: str = "INTERNAL_ERROR", status_code: int = 500
+    self,
+    message: str,
+    code: str = "INTERNAL_ERROR",
+    status_code: int = 500,
+    severity: str = "unrecoverable",
   ):
     """Initialize UcpError."""
     self.message = message
     self.code = code
     self.status_code = status_code
+    self.severity = severity
     super().__init__(self.message)
 
 
@@ -50,7 +56,12 @@ class ResourceNotFoundError(UcpError):
 
   def __init__(self, message: str):
     """Initialize ResourceNotFoundError."""
-    super().__init__(message, code="RESOURCE_NOT_FOUND", status_code=404)
+    super().__init__(
+      message,
+      code="RESOURCE_NOT_FOUND",
+      status_code=404,
+      severity="unrecoverable",
+    )
 
 
 class IdempotencyConflictError(UcpError):
@@ -58,7 +69,12 @@ class IdempotencyConflictError(UcpError):
 
   def __init__(self, message: str):
     """Initialize IdempotencyConflictError."""
-    super().__init__(message, code="IDEMPOTENCY_CONFLICT", status_code=409)
+    super().__init__(
+      message,
+      code="IDEMPOTENCY_CONFLICT",
+      status_code=409,
+      severity="unrecoverable",
+    )
 
 
 class CheckoutNotModifiableError(UcpError):
@@ -66,7 +82,12 @@ class CheckoutNotModifiableError(UcpError):
 
   def __init__(self, message: str):
     """Initialize CheckoutNotModifiableError."""
-    super().__init__(message, code="CHECKOUT_NOT_MODIFIABLE", status_code=409)
+    super().__init__(
+      message,
+      code="CHECKOUT_NOT_MODIFIABLE",
+      status_code=409,
+      severity="unrecoverable",
+    )
 
 
 class OutOfStockError(UcpError):
@@ -74,17 +95,30 @@ class OutOfStockError(UcpError):
 
   def __init__(self, message: str, status_code: int = 400):
     """Initialize OutOfStockError."""
-    super().__init__(message, code="OUT_OF_STOCK", status_code=status_code)
+    super().__init__(
+      message,
+      code="OUT_OF_STOCK",
+      status_code=status_code,
+      severity="unrecoverable",
+    )
 
 
 class PaymentFailedError(UcpError):
   """Raised when payment processing fails."""
 
   def __init__(
-    self, message: str, code: str = "PAYMENT_FAILED", status_code: int = 402
+    self,
+    message: str,
+    code: str = "PAYMENT_FAILED",
+    status_code: int = 402,
   ):
     """Initialize PaymentFailedError."""
-    super().__init__(message, code=code, status_code=status_code)
+    super().__init__(
+      message,
+      code=code,
+      status_code=status_code,
+      severity="requires_buyer_input",
+    )
 
 
 class InvalidRequestError(UcpError):
@@ -92,24 +126,25 @@ class InvalidRequestError(UcpError):
 
   def __init__(self, message: str):
     """Initialize InvalidRequestError."""
-    super().__init__(message, code="INVALID_REQUEST", status_code=400)
+    super().__init__(
+      message,
+      code="INVALID_REQUEST",
+      status_code=400,
+      severity="unrecoverable",
+    )
 
 
 class UcpVersionError(UcpError):
   """Raised when a UCP version string is invalid or unsupported."""
 
-  def __init__(self, message: str, code: str = "VERSION_INVALID_FORMAT"):
+  def __init__(
+    self,
+    message: str,
+    code: str = "VERSION_INVALID_FORMAT",
+    status_code: int = 400,
+    severity: str = "unrecoverable",
+  ):
     """Initialize UcpVersionError."""
-    super().__init__(message, code=code, status_code=400)
-
-  def to_detail(self) -> UcpErrorDetail:
-    """Return an error payload matching UCP REST error shape."""
-    return UcpErrorDetail(
-      errors=[
-        UcpErrorDetailItem(
-          code=self.code,
-          message=self.message,
-          severity="critical",
-        )
-      ]
+    super().__init__(
+      message, code=code, status_code=status_code, severity=severity
     )

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -340,7 +340,9 @@ class IntegrationTest(absltest.TestCase):
         json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 400)
-      self.assertIn("Insufficient stock", response.json()["detail"])
+      data = response.json()
+      self.assertEqual(data["ucp"]["status"], "error")
+      self.assertIn("Insufficient stock", data["messages"][0]["content"])
 
   def test_double_complete_checkout(self) -> None:
     """Test that completing a checkout twice is idempotent."""
@@ -372,8 +374,10 @@ class IntegrationTest(absltest.TestCase):
         json=payment_payload,
       )
       self.assertEqual(response.status_code, 409)
+      data = response.json()
+      self.assertEqual(data["ucp"]["status"], "error")
       self.assertEqual(
-        response.json()["detail"],
+        data["messages"][0]["content"],
         "Cannot complete checkout in state 'completed'",
       )
 
@@ -561,7 +565,9 @@ class IntegrationTest(absltest.TestCase):
         ),
       )
       self.assertEqual(response.status_code, 409)
-      self.assertIn("Cannot cancel checkout", response.json()["detail"])
+      data = response.json()
+      self.assertEqual(data["ucp"]["status"], "error")
+      self.assertIn("Cannot cancel checkout", data["messages"][0]["content"])
 
       # 4. Create another checkout and complete it, then try to cancel
       payload = self._create_checkout_payload(
@@ -595,7 +601,9 @@ class IntegrationTest(absltest.TestCase):
         ),
       )
       self.assertEqual(response.status_code, 409)
-      self.assertIn("Cannot cancel checkout", response.json()["detail"])
+      data = response.json()
+      self.assertEqual(data["ucp"]["status"], "error")
+      self.assertIn("Cannot cancel checkout", data["messages"][0]["content"])
 
   def _notify_and_capture(
     self, checkout: UnifiedCheckout, event_type: str
@@ -737,14 +745,15 @@ class IntegrationTest(absltest.TestCase):
       )
       self.assertEqual(response.status_code, 400)
 
-      # Verify the error structure matches UcpErrorDetail
+      # Verify the error structure matches UcpErrorResponse
       data = response.json()
-      self.assertIn("detail", data)
-      detail = data["detail"]
-      self.assertEqual(detail["status"], "error")
-      self.assertEqual(len(detail["errors"]), 1)
-      self.assertEqual(detail["errors"][0]["code"], "VERSION_INVALID_FORMAT")
-      self.assertEqual(detail["errors"][0]["severity"], "critical")
+      self.assertNotIn("detail", data)
+      self.assertEqual(data["ucp"]["status"], "error")
+      self.assertEqual(data["ucp"]["version"], app.version)
+      self.assertEqual(len(data["messages"]), 1)
+      self.assertEqual(data["messages"][0]["type"], "error")
+      self.assertEqual(data["messages"][0]["code"], "VERSION_INVALID_FORMAT")
+      self.assertEqual(data["messages"][0]["severity"], "unrecoverable")
 
   def test_version_unsupported(self) -> None:
     """Tests that UCP-Agent with unsupported (newer) version is rejected."""
@@ -764,14 +773,15 @@ class IntegrationTest(absltest.TestCase):
       )
       self.assertEqual(response.status_code, 422)
 
-      # Verify the error structure matches UcpErrorDetail
+      # Verify the error structure matches UcpErrorResponse
       data = response.json()
-      self.assertIn("detail", data)
-      detail = data["detail"]
-      self.assertEqual(detail["status"], "error")
-      self.assertEqual(len(detail["errors"]), 1)
-      self.assertEqual(detail["errors"][0]["code"], "VERSION_UNSUPPORTED")
-      self.assertEqual(detail["errors"][0]["severity"], "critical")
+      self.assertNotIn("detail", data)
+      self.assertEqual(data["ucp"]["status"], "error")
+      self.assertEqual(data["ucp"]["version"], app.version)
+      self.assertEqual(len(data["messages"]), 1)
+      self.assertEqual(data["messages"][0]["type"], "error")
+      self.assertEqual(data["messages"][0]["code"], "VERSION_UNSUPPORTED")
+      self.assertEqual(data["messages"][0]["severity"], "unrecoverable")
 
 
 if __name__ == "__main__":

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -28,6 +28,8 @@ import db
 import dependencies
 from fastapi.testclient import TestClient
 import respx
+from enums import ErrorSeverity, MessageType
+from exceptions import UcpErrorResponse, UcpMessageError
 from models import UnifiedCheckout
 from server.server import app
 from services.checkout_service import CheckoutService
@@ -342,6 +344,7 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(response.status_code, 400)
       data = response.json()
       self.assertEqual(data["ucp"]["status"], "error")
+      self.assertEqual(len(data["messages"]), 1)
       self.assertIn("Insufficient stock", data["messages"][0]["content"])
 
   def test_double_complete_checkout(self) -> None:
@@ -376,6 +379,7 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(response.status_code, 409)
       data = response.json()
       self.assertEqual(data["ucp"]["status"], "error")
+      self.assertEqual(len(data["messages"]), 1)
       self.assertEqual(
         data["messages"][0]["content"],
         "Cannot complete checkout in state 'completed'",
@@ -567,6 +571,7 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(response.status_code, 409)
       data = response.json()
       self.assertEqual(data["ucp"]["status"], "error")
+      self.assertEqual(len(data["messages"]), 1)
       self.assertIn("Cannot cancel checkout", data["messages"][0]["content"])
 
       # 4. Create another checkout and complete it, then try to cancel
@@ -603,6 +608,7 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(response.status_code, 409)
       data = response.json()
       self.assertEqual(data["ucp"]["status"], "error")
+      self.assertEqual(len(data["messages"]), 1)
       self.assertIn("Cannot cancel checkout", data["messages"][0]["content"])
 
   def _notify_and_capture(
@@ -748,12 +754,18 @@ class IntegrationTest(absltest.TestCase):
       # Verify the error structure matches UcpErrorResponse
       data = response.json()
       self.assertNotIn("detail", data)
-      self.assertEqual(data["ucp"]["status"], "error")
-      self.assertEqual(data["ucp"]["version"], app.version)
-      self.assertEqual(len(data["messages"]), 1)
-      self.assertEqual(data["messages"][0]["type"], "error")
-      self.assertEqual(data["messages"][0]["code"], "VERSION_INVALID_FORMAT")
-      self.assertEqual(data["messages"][0]["severity"], "unrecoverable")
+      expected = UcpErrorResponse(
+        ucp={"version": app.version, "status": "error"},
+        messages=[
+          UcpMessageError(
+            type=MessageType.ERROR,
+            code="VERSION_INVALID_FORMAT",
+            content=("Version 'bad-version' is invalid. Expected YYYY-MM-DD."),
+            severity=ErrorSeverity.UNRECOVERABLE,
+          )
+        ],
+      )
+      self.assertEqual(UcpErrorResponse.model_validate(data), expected)
 
   def test_version_unsupported(self) -> None:
     """Tests that UCP-Agent with unsupported (newer) version is rejected."""
@@ -776,12 +788,21 @@ class IntegrationTest(absltest.TestCase):
       # Verify the error structure matches UcpErrorResponse
       data = response.json()
       self.assertNotIn("detail", data)
-      self.assertEqual(data["ucp"]["status"], "error")
-      self.assertEqual(data["ucp"]["version"], app.version)
-      self.assertEqual(len(data["messages"]), 1)
-      self.assertEqual(data["messages"][0]["type"], "error")
-      self.assertEqual(data["messages"][0]["code"], "VERSION_UNSUPPORTED")
-      self.assertEqual(data["messages"][0]["severity"], "unrecoverable")
+      expected = UcpErrorResponse(
+        ucp={"version": app.version, "status": "error"},
+        messages=[
+          UcpMessageError(
+            type=MessageType.ERROR,
+            code="VERSION_UNSUPPORTED",
+            content=(
+              f"Version 2026-04-09 is not supported. This merchant"
+              f" implements version {app.version}."
+            ),
+            severity=ErrorSeverity.UNRECOVERABLE,
+          )
+        ],
+      )
+      self.assertEqual(UcpErrorResponse.model_validate(data), expected)
 
 
 if __name__ == "__main__":

--- a/rest/python/server/routes/discovery_profile.json
+++ b/rest/python/server/routes/discovery_profile.json
@@ -9,25 +9,6 @@
           "transport": "rest",
           "endpoint": "{{ENDPOINT}}",
           "schema": "https://ucp.dev/2026-04-08/services/shopping/openapi.json"
-        },
-        {
-          "version": "2026-04-08",
-          "spec": "https://ucp.dev/2026-04-08/specification/overview",
-          "transport": "mcp",
-          "endpoint": "{{ENDPOINT}}/mcp",
-          "schema": "https://ucp.dev/2026-04-08/services/shopping/openrpc.json"
-        },
-        {
-          "version": "2026-04-08",
-          "spec": "https://ucp.dev/2026-04-08/specification/overview",
-          "transport": "a2a",
-          "endpoint": "{{ENDPOINT}}/.well-known/agent-card.json"
-        },
-        {
-          "version": "2026-04-08",
-          "spec": "https://ucp.dev/2026-04-08/specification/overview",
-          "transport": "embedded",
-          "schema": "https://ucp.dev/2026-04-08/services/shopping/embedded.json"
         }
       ]
     },

--- a/rest/python/server/server.py
+++ b/rest/python/server/server.py
@@ -49,7 +49,20 @@ async def ucp_exception_handler(request: Request, exc: UcpError):
   del request  # Unused.
   return JSONResponse(
     status_code=exc.status_code,
-    content={"detail": exc.message, "code": exc.code},
+    content={
+      "ucp": {
+        "version": config.get_server_version(),
+        "status": "error",
+      },
+      "messages": [
+        {
+          "type": "error",
+          "code": exc.code,
+          "content": exc.message,
+          "severity": exc.severity,
+        }
+      ],
+    },
   )
 
 


### PR DESCRIPTION
# Description

This PR includes the following fixes:
1. **Python Server**: Trim unsupported transports (MCP, A2A, and Embedded) from the discovery profile. Currently, only the REST transport is fully implemented and served. Advertising other transports causes conformant agents to attempt using them, leading to errors or 404s.
2. **Node.js Server**: Correct the version negotiation error response. Return HTTP `422 Unprocessable Entity` with a structured `UcpErrorDetail` instead of HTTP `400 Bad Request` when the client requests an unsupported version, aligning with the spec and Python implementation.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Fixes https://github.com/Universal-Commerce-Protocol/samples/issues/133

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)
