### PR TITLE
fix(rest/python): seed valid totals when creating a checkout

### DIFF
--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -286,6 +286,12 @@ class CheckoutService:
 
       fulfillment_resp = FulfillmentResponseClass(methods=resp_methods)
 
+    # The SDK enforces the totals contains cardinality (exactly one subtotal
+    # and one total) on the response model. The server is the authority for
+    # totals and computes them in _recalculate_totals below, but that runs
+    # after construction. Seed a valid placeholder so the in-progress model
+    # satisfies the constraint at construction; it is overwritten with the
+    # authoritative amounts immediately. See python-sdk#57.
     checkout = Checkout(
       ucp=ResponseCheckout(
         version=config.get_server_version(),
@@ -303,7 +309,10 @@ class CheckoutService:
       status=CheckoutStatus.IN_PROGRESS,
       currency=checkout_req.currency,
       line_items=line_items,
-      totals=[],
+      totals=[
+        {"type": "subtotal", "amount": 0},
+        {"type": "total", "amount": 0},
+      ],
       links=[],
       payment=PaymentResponse(
         instruments=checkout_req.payment.instruments


### PR DESCRIPTION
## Problem

With the totals contains cardinality now enforced on the response models (exactly one `subtotal` and one `total`), every `POST /checkout-sessions` returns `500`.

`create_checkout` constructs the checkout with an empty `totals` list and fills it in during `_recalculate_totals` (the server is the authority for pricing). Construction runs the `totals` validator on that empty list and raises before recalculation:

```
pydantic_core.ValidationError: 1 validation error for UnifiedCheckout
totals
  Value error, Array must contain at least 1 entry matching type=='subtotal' (schema minContains=1)
```

The final wire document is fully valid (exactly one subtotal and one total) - this is purely about *when* the check fires.

## Fix

Seed a valid placeholder (`[{subtotal, 0}, {total, 0}]`) at construction so the in-progress model satisfies the constraint; `_recalculate_totals` overwrites it with the server-authoritative amounts immediately after. Construction stays fully validated (no `model_construct`, so extension fields like `discounts` are still coerced normally), and the emitted wire document is unchanged. Single-site change in `create_checkout` (the update path mutates an already-valid checkout via assignment, which is not validated).

Placeholder entries are passed as dicts so pydantic coerces them to the field's own `Total` type, avoiding a generated-class identity mismatch.

## Verification

Booted the reference flower-shop server and ran, with the totals validators active:

| | Before | After |
|---|---|---|
| Conformance suite | 2 pass / 67 fail | **69 pass / 0 fail** |

Also green **without** the validators (released SDK, as this repo's CI resolves it), confirming it is safe to land independently:
- Server integration tests (`rest/python/server pytest`): **16 passed**
- Happy-path client (`simple_happy_path_client.py`): **completed**

`ruff format --check` and `ruff check` clean.

Relates to Universal-Commerce-Protocol/python-sdk#57 (keeps that enforcement strict while keeping the reference server green).