### PR TITLE
fix(rest/python): rebuild discounts.applied idempotently on recalculation

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -535,6 +535,90 @@ class IntegrationTest(absltest.TestCase):
         "subtotal plus the signed discount must equal the total",
       )
 
+  def test_discount_applied_is_not_duplicated_on_update(self) -> None:
+    """An update that omits discounts must not duplicate discounts.applied.
+
+    _recalculate_totals rebuilds checkout.totals from scratch on every
+    create/update, but it appended to discounts.applied without first
+    resetting it. Because the persisted (and reloaded) checkout already
+    carries the applied entries from the previous response, an update that
+    does not re-submit the discounts field accumulated a duplicate applied
+    entry on every call. The server is the authority for applied discounts
+    (discount.json marks applied as ucp_request:"omit"), so the list must be
+    rebuilt idempotently, mirroring how totals is rebuilt.
+    """
+
+    async def seed_discount() -> None:
+      async with self.transactions_session_factory() as session:
+        await session.execute(delete(db.Discount))
+        session.add(
+          db.Discount(
+            code="10OFF", type="percentage", value=10, description="10% Off"
+          )
+        )
+        await session.commit()
+
+    asyncio.run(seed_discount())
+
+    with self.client:
+      checkout_id = "test_checkout_discount_dup"
+      # 1. Create with a discount code -> applied has exactly one entry.
+      payload = self._create_checkout_payload(
+        checkout_id, [("rose", "Red Rose", 1000, 1)]
+      )
+      body = payload.model_dump(mode="json", exclude_none=True)
+      body["discounts"] = {"codes": ["10OFF"]}
+      create = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="dup-1", request_id="dup-1"),
+        json=body,
+      )
+      self.assertEqual(create.status_code, 201, f"Response: {create.text}")
+      applied = (create.json().get("discounts") or {}).get("applied") or []
+      self.assertEqual(len(applied), 1, "create applies the discount once")
+
+      # 2. Update without re-submitting discounts (e.g. a quantity/address
+      #    change). applied must remain a single entry, not accumulate.
+      update_body = payload.model_dump(mode="json", exclude_none=True)
+      update = self.client.put(
+        f"/checkout-sessions/{checkout_id}",
+        headers=self._get_headers(idempotency_key="dup-2", request_id="dup-2"),
+        json=update_body,
+      )
+      self.assertEqual(update.status_code, 200, f"Response: {update.text}")
+      applied_after = (update.json().get("discounts") or {}).get(
+        "applied"
+      ) or []
+      self.assertEqual(
+        [a["code"] for a in applied_after],
+        ["10OFF"],
+        "the previously applied discount is retained",
+      )
+      self.assertEqual(
+        len(applied_after),
+        1,
+        "update must not duplicate discounts.applied entries",
+      )
+
+      # 3. The receipt is still correct after the update: exactly one
+      #    negative discount totals[] entry, and subtotal + discount == total
+      #    (proves the totals rebuild and the applied rebuild stay in sync).
+      totals_by_type: dict[str, int] = {}
+      discount_total_entries = 0
+      for t in update.json().get("totals", []):
+        totals_by_type[t["type"]] = t["amount"]
+        if t["type"] == "discount":
+          discount_total_entries += 1
+      self.assertEqual(discount_total_entries, 1, "one discount totals[] entry")
+      self.assertEqual(
+        totals_by_type.get("discount"), -100, "10% of the 1000 subtotal"
+      )
+      self.assertEqual(
+        totals_by_type.get("subtotal") + totals_by_type.get("discount"),
+        totals_by_type.get("total"),
+        "subtotal plus the signed discount must equal the total",
+      )
+
   def test_cancel_checkout(self) -> None:
     """Tests the checkout cancellation flow."""
     with self.client:

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -1133,6 +1133,14 @@ class CheckoutService:
     if not checkout.discounts:
       checkout.discounts = DiscountsObject()
 
+    # The server is the authority for applied discounts (discount.json marks
+    # applied as ucp_request:"omit"). _recalculate_totals runs on every
+    # create/update, and a reloaded checkout already carries the applied
+    # entries from the previous response. Rebuild the list from scratch,
+    # mirroring how `totals` is rebuilt above, so entries do not accumulate
+    # on every recalculation (e.g. an update that omits the discounts field).
+    checkout.discounts.applied = None
+
     if checkout.discounts.codes:
       # Batch fetch discounts to avoid N+1 queries
       discounts = await db.get_discounts_by_codes(


### PR DESCRIPTION
# Description

`_recalculate_totals` rebuilt `checkout.totals` from scratch on every create/update but appended to `discounts.applied` **without resetting it**. Because the persisted checkout (reloaded on each update) already carries the `applied` entries from the previous response, **an update that omits the `discounts` field accumulates a duplicate `applied` entry on every recalculation.**

**Repro:** create a checkout with `discounts.codes = ["10OFF"]` (response `applied` has 1 entry), then `PUT /checkout-sessions/{id}` with a body that omits `discounts` (e.g. a quantity / shipping change) → the response `discounts.applied` lists the discount twice, and keeps growing with each such update.

**Root cause** — `rest/python/server/services/checkout_service.py`, `_recalculate_totals`: `checkout.totals` is reset (`checkout.totals = []`) at the top of each recalculation, but `discounts.applied` is never reset, so it accumulates once the reloaded checkout brings back the prior entries.

**Fix:** reset `checkout.discounts.applied = None` before recomputing — the same "server is the authority, rebuild from scratch" pattern already used for `totals`. This matches `discount.json`, where `applied` carries `ucp_request: "omit"` (a server-authoritative output field), so it must be rebuilt idempotently rather than appended to.

## Category (Required)

- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)

## Related Issues

None — this is a newly identified bug in the Python sample server (unrelated to #121 / #134).

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable). — *N/A, no documentation changes.*
- [x] My changes pass all local linting and formatting checks. (`ruff check` + `ruff format` clean)
- [x] I have added tests that prove my fix is effective or that my feature works. (`test_discount_applied_is_not_duplicated_on_update`)
- [x] New and existing unit tests pass locally with my changes. (Python integration suite: 12 passed)
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. — *N/A, no schema changes.*
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. — *N/A, no schema changes.*

## Screenshots / Logs (if applicable)

Before/after from the regression test — `discounts.applied` after an update that omits the `discounts` field:

**Before (bug):**
```
applied == ["10OFF", "10OFF"]   # duplicated on each update
```

**After (fix):**
```
applied == ["10OFF"]            # rebuilt idempotently
```

Full Python integration suite:
```
12 passed, 2 warnings in 1.76s
```
