### PR TITLE
fix(rest/nodejs): block completion when fulfillment methods array is empty

### DIFF
--- a/rest/nodejs/src/api/checkout.ts
+++ b/rest/nodejs/src/api/checkout.ts
@@ -744,12 +744,17 @@ export class CheckoutService {
       return c.json({ detail: "Checkout session not found" }, 404);
     }
 
-    // Validate Fulfillment is complete
-    const hasFulfillment = checkout.fulfillment?.methods?.every(
-      (method) =>
-        method.selected_destination_id &&
-        method.groups?.every((group) => group.selected_option_id)
-    );
+    // Validate Fulfillment is complete. Require at least one method: an empty
+    // methods array must not satisfy the gate via [].every(...) === true.
+    const methods = checkout.fulfillment?.methods;
+    const hasFulfillment =
+      Array.isArray(methods) &&
+      methods.length > 0 &&
+      methods.every(
+        (method) =>
+          method.selected_destination_id &&
+          method.groups?.every((group) => group.selected_option_id)
+      );
 
     if (!hasFulfillment) {
       return c.json(

--- a/rest/nodejs/test/fulfillment.test.ts
+++ b/rest/nodejs/test/fulfillment.test.ts
@@ -265,3 +265,37 @@ test("a checkout with fulfillment fully selected can be completed", async () => 
   assert.equal(body.status, "completed");
   assert.ok(body.order?.id, "completion must assign an order id");
 });
+
+test("empty fulfillment methods array blocks completion", async () => {
+  const app = buildApp();
+  // Distinct from "no fulfillment at all": the request carries an explicit
+  // fulfillment object whose methods array is empty. The completion gate must
+  // not treat [].every(...) === true as "all methods satisfied".
+  const created = await app.request("/checkout-sessions", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({
+      currency: "USD",
+      line_items: LINE_ITEMS,
+      payment: {},
+      buyer: KNOWN_BUYER,
+      fulfillment: { methods: [] },
+    }),
+  });
+  assert.equal(created.status, 201);
+  const checkout = (await created.json()) as Checkout;
+  assert.ok(
+    Array.isArray(checkout.fulfillment?.methods) &&
+      checkout.fulfillment!.methods!.length === 0,
+    "the empty methods array is what makes the gate a vacuous truth"
+  );
+
+  const res = await app.request(`/checkout-sessions/${checkout.id}/complete`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(SUCCESS_PAYMENT),
+  });
+  assert.equal(res.status, 400);
+  const body = (await res.json()) as { detail: string };
+  assert.match(body.detail, /fulfillment/i);
+});


### PR DESCRIPTION
# Description

The Node.js completion gate used `checkout.fulfillment?.methods?.every(...)`, which is **vacuously true when `methods` is an empty array**. A checkout created with `fulfillment: { methods: [] }` therefore passed the "fulfillment selected" check and could be completed (order placed) with no fulfillment at all — while a checkout with no `fulfillment` field is correctly rejected.

**Repro:** `POST /checkout-sessions` with `fulfillment: { methods: [] }` returns 201, then `POST /checkout-sessions/{id}/complete` currently returns **200** (order placed, no fulfillment).

**Root cause** — `rest/nodejs/src/api/checkout.ts`, `completeCheckout`:

```js
const hasFulfillment = checkout.fulfillment?.methods?.every(
  (method) =>
    method.selected_destination_id &&
    method.groups?.every((group) => group.selected_option_id)
);
```

`[].every(fn)` evaluates to `true`, so an empty methods array satisfies the gate.

**Fix:** require the methods array to be non-empty before applying `.every(...)` (`Array.isArray(methods) && methods.length > 0 && methods.every(...)`). This matches the Python sample, whose `complete_checkout` blocks completion when `methods` is empty.

## Category (Required)

- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)

## Related Issues

None — newly identified bug in the Node.js sample server.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable). — *N/A, no documentation changes.*
- [x] My changes pass all local linting and formatting checks. (`tsc --noEmit` clean; `prettier` clean.)
- [x] I have added tests that prove my fix is effective or that my feature works. (`empty fulfillment methods array blocks completion`.)
- [x] New and existing unit tests pass locally with my changes. (Node.js suite: 29 passed.)
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. — *N/A, no schema changes.*
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. — *N/A, no schema changes.*

## Screenshots / Logs (if applicable)

Before/after — completing a checkout created with `fulfillment: { methods: [] }`:

**Before (bug):**
```
POST /checkout-sessions/{id}/complete -> 200   # order placed, no fulfillment
```

**After (fix):**
```
POST /checkout-sessions/{id}/complete -> 400   # "Fulfillment address and option must be selected"
```

Full Node.js suite:
```
# tests 29
# pass 29
# fail 0
```
