### PR TITLE
fix(rest/python): determine currency server side instead of reading it from the create request

### DIFF
--- a/rest/python/server/config.py
+++ b/rest/python/server/config.py
@@ -26,6 +26,18 @@ FLAGS = flags.FLAGS
 
 _SERVER_VERSION_CACHE = None
 
+# checkout.json annotates `currency` with `ucp_request: omit` and describes
+# it as "reflecting the merchant's market determination ... buyers provide
+# signals, merchants determine currency". A conformant platform therefore does
+# not send it, and the generated CheckoutCreateRequest has no such field. This
+# sample serves a single market, so the determination is a constant.
+DEFAULT_CURRENCY = "USD"
+
+
+def get_default_currency() -> str:
+  """Return the currency this business trades in."""
+  return DEFAULT_CURRENCY
+
 
 def get_server_version() -> str:
   """Read and cache the server version from the discovery profile."""

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -937,6 +937,50 @@ class IntegrationTest(absltest.TestCase):
       for forbidden in ("private", "no-store", "no-cache"):
         self.assertNotIn(forbidden, directives)
 
+  def test_create_omitting_server_determined_fields(self) -> None:
+    """A conformant create sends only line_items.
+
+    checkout.json marks currency (and id, status, totals, links) with
+    `ucp_request: omit`, describing currency as derived from address, context
+    and geo IP because merchants determine it. The generated
+    CheckoutCreateRequest carries no currency field for that reason, so a
+    platform following the schema sends neither.
+
+    The other tests build their payload with _create_checkout_payload, which
+    sets id and currency; extra="allow" keeps them, so checkout_req.currency
+    always resolves and this path is never exercised.
+    """
+    with self.client:
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="omit1", request_id="omit1"),
+        json={"line_items": [{"item": {"id": "rose"}, "quantity": 1}]},
+      )
+      self.assertEqual(response.status_code, 201, f"Response: {response.text}")
+      body = response.json()
+      self.assertIsInstance(
+        body.get("currency"),
+        str,
+        "server must determine a currency when the platform omits it",
+      )
+
+  def test_update_omitting_server_determined_fields(self) -> None:
+    """The update path reads the same omitted field and must not fail."""
+    with self.client:
+      created = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="omit2", request_id="omit2"),
+        json={"line_items": [{"item": {"id": "rose"}, "quantity": 1}]},
+      )
+      self.assertEqual(created.status_code, 201, f"Response: {created.text}")
+      checkout_id = self.get_resource_id(created.json()["id"])
+      updated = self.client.put(
+        f"/checkout-sessions/{checkout_id}",
+        headers=self._get_headers(idempotency_key="omit3", request_id="omit3"),
+        json={"line_items": [{"item": {"id": "rose"}, "quantity": 2}]},
+      )
+      self.assertEqual(updated.status_code, 200, f"Response: {updated.text}")
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -307,7 +307,7 @@ class CheckoutService:
       ),
       id=checkout_id,
       status=CheckoutStatus.IN_PROGRESS,
-      currency=checkout_req.currency,
+      currency=config.get_default_currency(),
       line_items=line_items,
       totals=[
         {"type": "subtotal", "amount": 0},
@@ -429,8 +429,10 @@ class CheckoutService:
         )
       existing.line_items = line_items
 
-    if checkout_req.currency:
-      existing.currency = checkout_req.currency
+    # `currency` carries `ucp_request: omit`, so the business determines it
+    # and an update never takes it from the request. Reading it here also
+    # raised AttributeError whenever a conformant platform omitted it, which
+    # is the same defect as the create path.
 
     if checkout_req.payment:
       existing.payment = PaymentResponse(


### PR DESCRIPTION
## What I ran into

A checkout create that follows the schema returns 500 from the Python sample
server. The same request succeeds once a field the schema says to omit is added,
which is what kept this off the radar.

## Observed against main (2e5b77c1)

Fresh clone, documented setup, seeded flower shop database:

    POST /checkout-sessions
    Content-Type: application/json
    UCP-Agent: profile="https://example.com/agent"

    {"line_items": [{"item": {"id": "bouquet_roses"}, "quantity": 1}]}

    HTTP 500  Internal Server Error

Server log:

    File "services/checkout_service.py", line 310, in create_checkout
        currency=checkout_req.currency,
    AttributeError: 'UnifiedCheckoutCreateRequest' object has no attribute 'currency'

Adding `"currency": "USD"` to the same body returns 201.

## Why I think the minimal body is the correct one

`source/schemas/shopping/checkout.json` annotates `currency` with
`ucp_request: omit`, and describes it as the merchant market determination,
derived from address, context and geo IP. `CheckoutCreateRequest` in the SDK has
no `currency` field for that reason, and `line_items` is its only required
member. So a platform following the schema sends exactly the body above, and
that is the body that fails.

`create_checkout` reads `checkout_req.currency` anyway. Because the model sets
`extra="allow"`, that attribute only resolves when a client sends a field the
schema told it to omit, and raises AttributeError otherwise.

## Scope

I swept for other reads of request fields marked omit and found one more, the
same pattern on the update path:

| Site | Status |
| --- | --- |
| `checkout_service.py:310` create, `currency=checkout_req.currency` | fixed, server determines it |
| `checkout_service.py:432` update, `if checkout_req.currency:` | fixed, update no longer takes currency from the request |
| `checkout_service.py:198` create, `model_dump(exclude={... "currency" ...})` | already correct, currency is excluded there |
| `rest/nodejs/src/api/checkout.ts:553` | already correct, sets currency server side |

The Node sample already determines currency itself, so this brings the Python
sample in line with it rather than introducing a new convention.

On the update path I removed the client driven override rather than making the
read tolerant, because the spec assigns the determination to the business. If
you would rather keep accepting a platform supplied currency there, I am happy
to switch that hunk to a tolerant read instead. That is a judgement call and
yours to make.

## Why CI did not catch it

Every integration test builds its payload through `_create_checkout_payload`,
which sets `id` and `currency`. Both are `ucp_request: omit` fields, and
`extra="allow"` keeps them, so `checkout_req.currency` always resolved and the
conformant path was never exercised.

## Verification

- `uv run --directory rest/python/server pytest`: 20 passed, including the two
  new tests
- Reverted each half of the fix in turn and confirmed the matching test fails,
  so the tests are load bearing rather than incidental
- Full workflow path from `python-server-tests.yml`: database init, server boot,
  and `simple_happy_path_client.py` end to end, exit 0 with no 500 in the log
- Pinned `pre-commit run` clean, ruff and ruff format both

Please let me know if the framing or the update path call looks wrong to you and
I will adjust.
