### PR TITLE
fix(rest/nodejs): express discount allocation path as a JSONPath

### DIFF
--- a/rest/nodejs/src/api/checkout.ts
+++ b/rest/nodejs/src/api/checkout.ts
@@ -412,7 +412,12 @@ export class CheckoutService {
             code,
             title: "10% Off",
             amount: discountAmount,
-            allocations: [{ path: "subtotal", amount: discountAmount }],
+            allocations: [
+              {
+                path: "$.totals[?(@.type=='subtotal')]",
+                amount: discountAmount,
+              },
+            ],
           });
           checkout.totals.push({ type: "discount", amount: -discountAmount });
         } else if (upperCode === "WELCOME20") {
@@ -422,7 +427,12 @@ export class CheckoutService {
             code,
             title: "Welcome 20% Off",
             amount: discountAmount,
-            allocations: [{ path: "subtotal", amount: discountAmount }],
+            allocations: [
+              {
+                path: "$.totals[?(@.type=='subtotal')]",
+                amount: discountAmount,
+              },
+            ],
           });
           checkout.totals.push({ type: "discount", amount: -discountAmount });
         } else if (upperCode === "FIXED500") {
@@ -432,7 +442,12 @@ export class CheckoutService {
             code,
             title: "$5.00 Off",
             amount: discountAmount,
-            allocations: [{ path: "subtotal", amount: discountAmount }],
+            allocations: [
+              {
+                path: "$.totals[?(@.type=='subtotal')]",
+                amount: discountAmount,
+              },
+            ],
           });
           checkout.totals.push({ type: "discount", amount: -discountAmount });
         }

--- a/rest/nodejs/test/discount.test.ts
+++ b/rest/nodejs/test/discount.test.ts
@@ -132,3 +132,33 @@ test("an applied discount's allocations sum to its amount", () => {
   }
   assert.ok(checked > 0, "expected at least one discount carrying allocations");
 });
+
+// An allocation target must be expressed as a JSONPath (discount.json:
+// allocation.path), so a platform can resolve where the discount applied —
+// not a bare label like "subtotal".
+test("an applied discount's allocation path is a JSONPath", () => {
+  const checkout = checkoutWithCodes(["10OFF"]);
+  new CheckoutService()["recalculateTotals"](checkout);
+
+  const applied = (
+    checkout as unknown as {
+      discounts: {
+        applied: Array<{
+          allocations?: Array<{ path: string; amount: number }>;
+        }>;
+      };
+    }
+  ).discounts.applied;
+
+  let checked = 0;
+  for (const a of applied) {
+    for (const alloc of a.allocations ?? []) {
+      checked += 1;
+      assert.ok(
+        alloc.path.startsWith("$."),
+        `allocation path "${alloc.path}" must be a JSONPath rooted at "$."`
+      );
+    }
+  }
+  assert.ok(checked > 0, "expected at least one allocation to check");
+});


### PR DESCRIPTION
# Description

`discount.json` types `allocation.path` as a JSONPath (RFC 9535) pointing at the allocation target (e.g. `"$.line_items[0]"`). The Node.js sample emitted the bare label `"subtotal"` for every applied discount's allocation, which a platform cannot resolve as a path. The Python sample already emits `"$.totals[?(@.type=='subtotal')]"`.

**Root cause** — `rest/nodejs/src/api/checkout.ts`, `recalculateTotals`: all three discount code branches (`10OFF`, `WELCOME20`, `FIXED500`) built `allocations: [{ path: "subtotal", amount }]`.

**Fix:** emit `"$.totals[?(@.type=='subtotal')]"` instead — the same JSONPath the Python reference uses. `totals` is an array of `{ type, amount }` objects, so the filter expression is the correct way to target the subtotal entry (a dot-path would be wrong). Allocation amounts are unchanged.

## Category (Required)

- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)

## Related Issues

None — newly identified spec-compliance gap in the Node.js sample server.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable). — *N/A, no documentation changes.*
- [x] My changes pass all local linting and formatting checks. (`tsc --noEmit` clean; `prettier` clean.)
- [x] I have added tests that prove my fix is effective or that my feature works. (`an applied discount's allocation path is a JSONPath` — fails on the old `"subtotal"` value.)
- [x] New and existing unit tests pass locally with my changes. (Node.js suite: 30 passed.)
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. — *N/A, no schema changes.*
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. — *N/A, no schema changes.*

## Screenshots / Logs (if applicable)

Before/after — an applied discount's `allocations[0].path`:

**Before (bug):**
```
"allocations": [{ "path": "subtotal", "amount": 100 }]
```

**After (fix):**
```
"allocations": [{ "path": "$.totals[?(@.type=='subtotal')]", "amount": 100 }]
```

Full Node.js suite:
```
# tests 30
# pass 30
# fail 0
```
