### PR TITLE
fix(rest/python): derive unsupported test version dynamically

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -880,9 +880,9 @@ class IntegrationTest(absltest.TestCase):
         "test_version_unsupported", [("rose", "Red Rose", 1000, 1)]
       )
       headers = self._get_headers(idempotency_key="ver_2", request_id="ver_2")
-      # Server version is 2026-04-08, so 2026-04-09 should be unsupported
+      version = datetime.date.fromisoformat(app.version) + datetime.timedelta(1)
       headers["UCP-Agent"] = (
-        'profile="https://agent.example/profile"; version="2026-04-09"'
+        f'profile="https://agent.example/profile"; version="{version}"'
       )
       response = self.client.post(
         "/checkout-sessions",
@@ -901,7 +901,7 @@ class IntegrationTest(absltest.TestCase):
             type=MessageType.ERROR,
             code="VERSION_UNSUPPORTED",
             content=(
-              f"Version 2026-04-09 is not supported. This merchant"
+              f"Version {version} is not supported. This merchant"
               f" implements version {app.version}."
             ),
             severity=ErrorSeverity.UNRECOVERABLE,


### PR DESCRIPTION
## Summary

- derive the unsupported client version as one day after `app.version`
- use the derived version in both the `UCP-Agent` header and expected error response
- keep the integration test valid when the discovery profile version advances

## Testing

- `uv run --directory rest/python/server pytest -v` (20 passed)
- `pre-commit run --files rest/python/server/integration_test.py`