### PR TITLE
fix(rest/python): scope idempotency hashes to checkout operations

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -294,6 +294,38 @@ class IntegrationTest(absltest.TestCase):
     )
     return payload.model_dump(mode="json", exclude_none=True)
 
+  def _perform_checkout_operation(
+    self,
+    operation: str,
+    checkout_id: str,
+    idempotency_key: str,
+    request_id: str,
+    request_body: dict | None,
+  ):
+    """Perform a checkout write operation for idempotency tests."""
+    headers = self._get_headers(
+      idempotency_key=idempotency_key,
+      request_id=request_id,
+    )
+    if operation == "update":
+      return self.client.put(
+        f"/checkout-sessions/{checkout_id}",
+        headers=headers,
+        json=request_body,
+      )
+    if operation == "complete":
+      return self.client.post(
+        f"/checkout-sessions/{checkout_id}/complete",
+        headers=headers,
+        json=request_body,
+      )
+    if operation == "cancel":
+      return self.client.post(
+        f"/checkout-sessions/{checkout_id}/cancel",
+        headers=headers,
+      )
+    raise ValueError(f"Unsupported checkout operation: {operation}")
+
   def test_single_item_checkout(self) -> None:
     """Test the full lifecycle of a single item checkout."""
     with self.client:
@@ -695,6 +727,93 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(data["ucp"]["status"], "error")
       self.assertEqual(len(data["messages"]), 1)
       self.assertIn("Cannot cancel checkout", data["messages"][0]["content"])
+
+  def test_idempotency_key_is_scoped_to_operation_and_checkout(self) -> None:
+    """An idempotency key only replays the exact same checkout operation."""
+    with self.client:
+      for operation in ("update", "complete", "cancel"):
+        with self.subTest(operation=operation):
+          first_checkout_id = f"idempotency_{operation}_first"
+          second_checkout_id = f"idempotency_{operation}_second"
+
+          for checkout_id in (first_checkout_id, second_checkout_id):
+            payload = self._create_checkout_payload(
+              checkout_id, [("rose", "Red Rose", 1000, 1)]
+            )
+            response = self.client.post(
+              "/checkout-sessions",
+              headers=self._get_headers(
+                idempotency_key=f"create_{checkout_id}",
+                request_id=f"create_{checkout_id}",
+              ),
+              json=payload.model_dump(mode="json", exclude_none=True),
+            )
+            self.assertEqual(response.status_code, 201, response.text)
+
+          shared_key = f"shared_{operation}_key"
+          request_body = None
+          if operation == "update":
+            request_body = {
+              "line_items": [
+                {
+                  "id": "shared_line_item",
+                  "quantity": 2,
+                  "item": {"id": "rose"},
+                }
+              ]
+            }
+          elif operation == "complete":
+            request_body = self._create_payment_payload()
+
+          first_response = self._perform_checkout_operation(
+            operation,
+            first_checkout_id,
+            shared_key,
+            f"{operation}_first",
+            request_body,
+          )
+          self.assertEqual(first_response.status_code, 200, first_response.text)
+
+          replay_response = self._perform_checkout_operation(
+            operation,
+            first_checkout_id,
+            shared_key,
+            f"{operation}_replay",
+            request_body,
+          )
+          self.assertEqual(
+            replay_response.status_code, 200, replay_response.text
+          )
+          self.assertEqual(replay_response.json(), first_response.json())
+
+          conflict_response = self._perform_checkout_operation(
+            operation,
+            second_checkout_id,
+            shared_key,
+            f"{operation}_second",
+            request_body,
+          )
+          self.assertEqual(
+            conflict_response.status_code, 409, conflict_response.text
+          )
+          self.assertEqual(
+            conflict_response.json()["messages"][0]["code"],
+            "IDEMPOTENCY_CONFLICT",
+          )
+
+          second_checkout = self.client.get(
+            f"/checkout-sessions/{second_checkout_id}",
+            headers=self._get_headers(
+              idempotency_key=f"get_{second_checkout_id}",
+              request_id=f"get_{second_checkout_id}",
+            ),
+          )
+          self.assertEqual(
+            second_checkout.status_code, 200, second_checkout.text
+          )
+          second_checkout_data = second_checkout.json()
+          self.assertEqual(second_checkout_data["status"], "ready_for_complete")
+          self.assertEqual(second_checkout_data["line_items"][0]["quantity"], 1)
 
   def _notify_and_capture(
     self, checkout: UnifiedCheckout, event_type: str

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -123,16 +123,25 @@ class CheckoutService:
     self.transactions_session = transactions_session
     self.base_url = base_url.rstrip("/")
 
-  def _compute_hash(self, data: Any) -> str:
-    """Compute SHA256 hash of the JSON-serialized data."""
+  def _compute_hash(
+    self,
+    operation: str,
+    data: Any,
+    resource_id: str | None = None,
+  ) -> str:
+    """Compute a hash of an idempotent operation's complete identity."""
     if isinstance(data, BaseModel):
       # Pydantic's optimized JSON dump
       # sort_keys is not supported in model_dump_json in Pydantic V2.
       # We dump to dict and use standard json.dumps for deterministic sorting.
-      json_str = json.dumps(data.model_dump(mode="json"), sort_keys=True)
-    else:
-      # sort_keys=True ensures deterministic hashing for dicts
-      json_str = json.dumps(data, sort_keys=True)
+      data = data.model_dump(mode="json")
+    request_identity = {
+      "operation": operation,
+      "resource_id": resource_id,
+      "data": data,
+    }
+    # sort_keys=True ensures deterministic hashing for dicts.
+    json_str = json.dumps(request_identity, sort_keys=True)
     return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
 
   async def create_checkout(
@@ -145,7 +154,7 @@ class CheckoutService:
     logger.info("Creating checkout session")
 
     # Idempotency Check
-    request_hash = self._compute_hash(checkout_req)
+    request_hash = self._compute_hash("create_checkout", checkout_req)
     existing_record = await db.get_idempotency_record(
       self.transactions_session, idempotency_key
     )
@@ -384,7 +393,9 @@ class CheckoutService:
     logger.info("Updating checkout session %s", checkout_id)
 
     # Idempotency Check
-    request_hash = self._compute_hash(checkout_req)
+    request_hash = self._compute_hash(
+      "update_checkout", checkout_req, resource_id=checkout_id
+    )
 
     existing_record = await db.get_idempotency_record(
       self.transactions_session, idempotency_key
@@ -621,7 +632,9 @@ class CheckoutService:
       if checkout_complete
       else None,
     }
-    request_hash = self._compute_hash(combined_data)
+    request_hash = self._compute_hash(
+      "complete_checkout", combined_data, resource_id=checkout_id
+    )
 
     existing_record = await db.get_idempotency_record(
       self.transactions_session, idempotency_key
@@ -907,7 +920,9 @@ class CheckoutService:
 
     # Idempotency Check
     # Payload is empty for cancel usually.
-    request_hash = self._compute_hash({})
+    request_hash = self._compute_hash(
+      "cancel_checkout", {}, resource_id=checkout_id
+    )
 
     existing_record = await db.get_idempotency_record(
       self.transactions_session, idempotency_key


### PR DESCRIPTION
## Summary

- include the checkout operation and target resource in idempotency request fingerprints
- reject reuse of an idempotency key for a different checkout instead of replaying another checkout's cached response
- preserve cached responses for exact retries of update, complete, and cancel operations
- add regression coverage for same-request replay and cross-checkout conflicts

## Why

Idempotency records are keyed globally, but the previous request hash only covered the request body. The checkout ID lives in the URL for update, complete, and cancel requests, and cancel requests all have the same empty body. Reusing a key for a different checkout could therefore return the first checkout's cached response with HTTP 200 while leaving the requested checkout unchanged.

The request fingerprint now includes the operation, resource ID, and request data. Exact retries still return the cached response, while reusing the key for a different operation or checkout returns `409 IDEMPOTENCY_CONFLICT`.

## Testing

- `.venv/bin/python -m pytest -v` (`133 passed`, `6 subtests passed`)
- pre-commit hooks for the changed files
- `git diff --check origin/main..HEAD`