### PR TITLE
fix(rest/python): assign checkout id server side instead of trusting the request

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -340,13 +340,16 @@ class IntegrationTest(absltest.TestCase):
       )
       self.assertEqual(response.status_code, 201, f"Response: {response.text}")
       checkout = TestCheckout.model_validate(response.json())
-      self.assertEqual(self.get_resource_id(checkout.id), "test_checkout_1")
+      # `id` is ucp_request: omit, so the server assigns it; follow-up
+      # operations use the returned id.
+      checkout_sid = self.get_resource_id(checkout.id)
+      self.assertIsInstance(checkout_sid, str)
       self.assertEqual(checkout.status, "ready_for_complete")
 
       # 2. Complete Checkout
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-        "/checkout-sessions/test_checkout_1/complete",
+        f"/checkout-sessions/{checkout_sid}/complete",
         headers=self._get_headers(idempotency_key="2", request_id="2"),
         json=payment_payload,
       )
@@ -393,11 +396,12 @@ class IntegrationTest(absltest.TestCase):
         json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
+      checkout_sid = self.get_resource_id(response.json()["id"])
 
       # 2. Complete Checkout (First time)
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-        "/checkout-sessions/test_checkout_double/complete",
+        f"/checkout-sessions/{checkout_sid}/complete",
         headers=self._get_headers(idempotency_key="2", request_id="2"),
         json=payment_payload,
       )
@@ -405,7 +409,7 @@ class IntegrationTest(absltest.TestCase):
 
       # 3. Complete Checkout (Second time) - Should fail
       response = self.client.post(
-        "/checkout-sessions/test_checkout_double/complete",
+        f"/checkout-sessions/{checkout_sid}/complete",
         headers=self._get_headers(idempotency_key="4", request_id="4"),
         json=payment_payload,
       )
@@ -432,11 +436,12 @@ class IntegrationTest(absltest.TestCase):
         json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
+      checkout_sid = self.get_resource_id(response.json()["id"])
 
       # 2. Complete Multi-item Checkout
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-        "/checkout-sessions/test_checkout_multi/complete",
+        f"/checkout-sessions/{checkout_sid}/complete",
         headers=self._get_headers(idempotency_key="6", request_id="6"),
         json=payment_payload,
       )
@@ -606,6 +611,7 @@ class IntegrationTest(absltest.TestCase):
         json=body,
       )
       self.assertEqual(create.status_code, 201, f"Response: {create.text}")
+      checkout_id = self.get_resource_id(create.json()["id"])
       applied = (create.json().get("discounts") or {}).get("applied") or []
       self.assertEqual(len(applied), 1, "create applies the discount once")
 
@@ -666,10 +672,11 @@ class IntegrationTest(absltest.TestCase):
         json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
+      checkout_sid = self.get_resource_id(response.json()["id"])
 
       # 2. Cancel Checkout
       response = self.client.post(
-        "/checkout-sessions/test_checkout_cancel/cancel",
+        f"/checkout-sessions/{checkout_sid}/cancel",
         headers=self._get_headers(
           idempotency_key="cancel_2", request_id="cancel_2"
         ),
@@ -680,7 +687,7 @@ class IntegrationTest(absltest.TestCase):
 
       # 3. Try to Cancel again (should fail)
       response = self.client.post(
-        "/checkout-sessions/test_checkout_cancel/cancel",
+        f"/checkout-sessions/{checkout_sid}/cancel",
         headers=self._get_headers(
           idempotency_key="cancel_3", request_id="cancel_3"
         ),
@@ -703,11 +710,12 @@ class IntegrationTest(absltest.TestCase):
         json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201)
+      completed_sid = self.get_resource_id(response.json()["id"])
 
       # Complete it
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-        "/checkout-sessions/test_checkout_cancel_completed/complete",
+        f"/checkout-sessions/{completed_sid}/complete",
         headers=self._get_headers(
           idempotency_key="cancel_5", request_id="cancel_5"
         ),
@@ -717,7 +725,7 @@ class IntegrationTest(absltest.TestCase):
 
       # Try to cancel completed checkout
       response = self.client.post(
-        "/checkout-sessions/test_checkout_cancel_completed/cancel",
+        f"/checkout-sessions/{completed_sid}/cancel",
         headers=self._get_headers(
           idempotency_key="cancel_6", request_id="cancel_6"
         ),
@@ -733,22 +741,26 @@ class IntegrationTest(absltest.TestCase):
     with self.client:
       for operation in ("update", "complete", "cancel"):
         with self.subTest(operation=operation):
-          first_checkout_id = f"idempotency_{operation}_first"
-          second_checkout_id = f"idempotency_{operation}_second"
-
-          for checkout_id in (first_checkout_id, second_checkout_id):
+          # The server assigns the checkout ids; the labels only scope the
+          # idempotency keys of the create calls.
+          server_ids: dict[str, str] = {}
+          for label in ("first", "second"):
             payload = self._create_checkout_payload(
-              checkout_id, [("rose", "Red Rose", 1000, 1)]
+              f"idempotency_{operation}_{label}",
+              [("rose", "Red Rose", 1000, 1)],
             )
             response = self.client.post(
               "/checkout-sessions",
               headers=self._get_headers(
-                idempotency_key=f"create_{checkout_id}",
-                request_id=f"create_{checkout_id}",
+                idempotency_key=f"create_idempotency_{operation}_{label}",
+                request_id=f"create_idempotency_{operation}_{label}",
               ),
               json=payload.model_dump(mode="json", exclude_none=True),
             )
             self.assertEqual(response.status_code, 201, response.text)
+            server_ids[label] = self.get_resource_id(response.json()["id"])
+          first_checkout_id = server_ids["first"]
+          second_checkout_id = server_ids["second"]
 
           shared_key = f"shared_{operation}_key"
           request_body = None
@@ -869,10 +881,11 @@ class IntegrationTest(absltest.TestCase):
         json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201, response.text)
+      checkout_sid = self.get_resource_id(response.json()["id"])
 
       payment_payload = self._create_payment_payload()
       response = self.client.post(
-        "/checkout-sessions/wh_order_placed/complete",
+        f"/checkout-sessions/{checkout_sid}/complete",
         headers=self._get_headers(idempotency_key="wh2", request_id="wh2"),
         json=payment_payload,
       )
@@ -1102,6 +1115,78 @@ class IntegrationTest(absltest.TestCase):
         json={"line_items": [{"item": {"id": "rose"}, "quantity": 2}]},
       )
       self.assertEqual(updated.status_code, 200, f"Response: {updated.text}")
+
+  def test_create_assigns_id_server_side(self) -> None:
+    """A create carrying a non-string top-level `id` must not 500.
+
+    checkout.json marks `id` with `ucp_request: omit` -- the business assigns
+    it -- so the generated CheckoutCreateRequest declares no id field, and a
+    request carrying one of any JSON type is still schema-valid because
+    extra="allow" admits it as an extra member. create_checkout read that
+    extra attribute and passed it into the Checkout response model verbatim,
+    so `"id": 123` raised an uncaught pydantic ValidationError (HTTP 500).
+    Same defect class as the currency read fixed in #156: the server
+    determines the value and never takes it from the request.
+    """
+
+    def _body(**extra: object) -> dict:
+      body = {
+        "currency": "USD",
+        "line_items": [
+          {
+            "id": "li_1",
+            "quantity": 1,
+            "item": {"id": "rose", "price": 1000},
+            "totals": [],
+          }
+        ],
+        "payment": {"instruments": [], "handlers": []},
+        "status": "incomplete",
+        "ucp": {"version": "2026-04-08"},
+        "totals": [],
+        "links": [],
+      }
+      body.update(extra)
+      return body
+
+    with self.client:
+      # A non-string id is schema-valid (id is omit, so it arrives as an
+      # extra member) and must never 500.
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="sid1", request_id="sid1"),
+        json=_body(id=123),
+      )
+      self.assertEqual(response.status_code, 201, f"Response: {response.text}")
+      self.assertIsInstance(
+        response.json().get("id"),
+        str,
+        "server must assign a string id when the platform sends a non-string",
+      )
+
+      # A string id is ignored the same way: the server assigns its own.
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="sid2", request_id="sid2"),
+        json=_body(id="client_chosen_id"),
+      )
+      self.assertEqual(response.status_code, 201, f"Response: {response.text}")
+      body = response.json()
+      self.assertIsInstance(body.get("id"), str)
+      self.assertNotIn(
+        "client_chosen_id",
+        body["id"],
+        "id is ucp_request: omit, so the server assigns it",
+      )
+
+      # Omitted id keeps working (the conformant request).
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(idempotency_key="sid3", request_id="sid3"),
+        json=_body(),
+      )
+      self.assertEqual(response.status_code, 201, f"Response: {response.text}")
+      self.assertIsInstance(response.json().get("id"), str)
 
 
 if __name__ == "__main__":

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -167,8 +167,13 @@ class CheckoutService:
       # Return cached response
       return Checkout(**existing_record.response_body)
 
-    # Initialize full model from request
-    checkout_id = getattr(checkout_req, "id", None) or str(uuid.uuid4())
+    # `id` carries `ucp_request: omit`, so the server assigns it and never
+    # takes it from the request. The generated CheckoutCreateRequest declares
+    # no id field, but extra="allow" admits a client-sent `id` of any JSON
+    # type as an extra attribute; reading it here propagated that raw value
+    # into the response model, where a non-string raised an uncaught
+    # ValidationError. Same defect class as the currency read fixed in #156.
+    checkout_id = str(uuid.uuid4())
 
     # Map line items
     line_items = []


### PR DESCRIPTION
## Observed

`POST /checkout-sessions` returns HTTP 500 when the request carries a non-string top-level `id`. `id` is annotated `ucp_request: omit` (server-assigned), so a request that includes it is schema-valid and a conformant platform may send anything there — but the reference crashes on a non-string value.

Full reproducing request (a spec-valid create; the id is the only variable):
```
POST /checkout-sessions
UCP-Agent: profile="https://spck.dev/agent"
idempotency-key: <uuid>   request-id: <uuid>   Content-Type: application/json

{"id":123,"currency":"USD","line_items":[{"id":"li_1","quantity":1,
 "item":{"id":"bouquet_roses","price":1000},"totals":[]}],
 "payment":{"instruments":[],"handlers":[]},"status":"incomplete",
 "ucp":{"version":"2026-04-08"},"totals":[],"links":[]}
→ HTTP 500
```
Controls: `id` omitted → 201, `id:"x"` (string) → 201.

Root cause: the generated `CheckoutCreateRequest` declares no `id` field (omit at 2026-04-08) but `extra="allow"` admits a client `id` of any type; `create_checkout` read it back with `getattr(checkout_req, "id", None)` and passed it into `Checkout(id=…)`, whose `id` is a required string, raising an uncaught pydantic `ValidationError`.

This is the direct sibling of #156 (which fixed the same class for `currency` by determining it server-side instead of reading it from the request).

## Fix

`services/checkout_service.py` — assign the id server-side unconditionally instead of trusting the request:
```
-    checkout_id = getattr(checkout_req, "id", None) or str(uuid.uuid4())
+    checkout_id = str(uuid.uuid4())
```
The update path has no analogue (it takes the id from the URL, never a body id). Class check: every other server-managed omit field (`status`, `totals`, `links`, `ucp`, `expires_at`, and `currency` from #156) already returns 201 on a wrong-typed value; `id` was the last one reading the request unsanitized.

## Verification

- New test `test_create_assigns_id_server_side` (integration_test.py, alongside #156's omit tests) fails on the old code with the exact `ValidationError`, passes after; kill-tested.
- Full `uv run pytest`: 135 passed. Happy-path client end to end: exit 0. Pinned pre-commit (ruff + ruff-format) clean.
- Live: the request above returns 201 with a server-assigned string id after the change.
- Why CI missed it: every existing test builds payloads with a string id, so a non-string id was never exercised.

## Note

A few existing lifecycle tests were reusing the client-chosen id in follow-up URLs; they now use the server-returned id (what the happy-path client already did). There is an adjacent class of unrelated extras (e.g. `continue_url`, `order`, `messages`, `platform`) that still 500 by colliding with response-only fields — out of scope here; happy to send a follow-up that builds the checkout from declared request fields only.
