### PR TITLE
fix(rest/nodejs): scope idempotency hashes to checkout operations

### DIFF
--- a/rest/nodejs/src/api/checkout.ts
+++ b/rest/nodejs/src/api/checkout.ts
@@ -62,7 +62,21 @@ import { type IdParamContext } from "../utils/validation";
  * Service for managing checkout sessions.
  */
 export class CheckoutService {
-  private computeHash(data: unknown): string {
+  private computeHash(
+    operation: string,
+    data: unknown,
+    resourceId?: string
+  ): string {
+    // Scope the fingerprint to the operation and, for update/complete/cancel,
+    // the target checkout id — so a key cannot replay a different checkout or
+    // a different operation. Mirrors the Python sample's idempotency scoping.
+    // resourceId is always present (null for create), matching the Python
+    // payload shape.
+    const payload = {
+      operation,
+      resourceId: resourceId ?? null,
+      data,
+    };
     const replacer = (_key: string, value: unknown) =>
       typeof value === "object" && value !== null && !Array.isArray(value)
         ? Object.keys(value as Record<string, unknown>)
@@ -73,7 +87,7 @@ export class CheckoutService {
             }, {})
         : value;
     return createHash("sha256")
-      .update(JSON.stringify(data, replacer))
+      .update(JSON.stringify(payload, replacer))
       .digest("hex");
   }
 
@@ -502,7 +516,7 @@ export class CheckoutService {
     let requestHash = "";
 
     if (idempotencyKey) {
-      requestHash = this.computeHash(request);
+      requestHash = this.computeHash("create_checkout", request);
       const record = getIdempotencyRecord(idempotencyKey);
       if (record) {
         if (record.request_hash !== requestHash) {
@@ -632,7 +646,7 @@ export class CheckoutService {
     let requestHash = "";
 
     if (idempotencyKey) {
-      requestHash = this.computeHash(updateRequest);
+      requestHash = this.computeHash("update_checkout", updateRequest, id);
       const record = getIdempotencyRecord(idempotencyKey);
       if (record) {
         if (record.request_hash !== requestHash) {
@@ -752,7 +766,7 @@ export class CheckoutService {
 
     // Idempotency check for payment data
     if (idempotencyKey) {
-      requestHash = this.computeHash(rawBody);
+      requestHash = this.computeHash("complete_checkout", rawBody, id);
       const record = getIdempotencyRecord(idempotencyKey);
       if (record) {
         if (record.request_hash !== requestHash) {
@@ -1009,7 +1023,7 @@ export class CheckoutService {
     let requestHash = "";
 
     if (idempotencyKey) {
-      requestHash = this.computeHash(rawBody);
+      requestHash = this.computeHash("cancel_checkout", rawBody, id);
       const record = getIdempotencyRecord(idempotencyKey);
       if (record) {
         if (record.request_hash !== requestHash) {

--- a/rest/nodejs/test/idempotency.test.ts
+++ b/rest/nodejs/test/idempotency.test.ts
@@ -20,8 +20,11 @@ import { Hono } from "hono";
 
 import { CheckoutService } from "../src/api/checkout";
 import { getProductsDb, getTransactionsDb, initDbs } from "../src/data/db";
-import { ExtendedCheckoutCreateRequestSchema } from "../src/models";
-import { prettyValidation } from "../src/utils/validation";
+import {
+  ExtendedCheckoutCreateRequestSchema,
+  ExtendedCheckoutUpdateRequestSchema,
+} from "../src/models";
+import { IdParamSchema, prettyValidation } from "../src/utils/validation";
 
 function buildApp() {
   const svc = new CheckoutService();
@@ -103,4 +106,91 @@ test("no idempotency key creates independent checkouts", async () => {
   const a = (await post(app, BODY).then((r) => r.json())) as { id: string };
   const b = (await post(app, BODY).then((r) => r.json())) as { id: string };
   assert.notEqual(a.id, b.id, "distinct requests must get distinct ids");
+});
+
+// A fuller app wiring create/update/cancel so idempotency scoping across
+// operations and checkouts can be exercised end to end.
+function buildFullApp() {
+  const svc = new CheckoutService();
+  const app = new Hono<{ Variables: { logger: typeof console } }>();
+  app.use(async (c, next) => {
+    c.set("logger", console);
+    await next();
+  });
+  app.post(
+    "/checkout-sessions",
+    zValidator("json", ExtendedCheckoutCreateRequestSchema, prettyValidation),
+    svc.createCheckout
+  );
+  app.put(
+    "/checkout-sessions/:id",
+    zValidator("param", IdParamSchema, prettyValidation),
+    zValidator("json", ExtendedCheckoutUpdateRequestSchema, prettyValidation),
+    svc.updateCheckout
+  );
+  app.post(
+    "/checkout-sessions/:id/cancel",
+    zValidator("param", IdParamSchema, prettyValidation),
+    svc.cancelCheckout
+  );
+  return app;
+}
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+async function newCheckout(app: ReturnType<typeof buildFullApp>) {
+  const res = await app.request("/checkout-sessions", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(BODY),
+  });
+  assert.equal(res.status, 201);
+  return (await res.json()) as { id: string };
+}
+
+// An idempotency key must be scoped to the checkout it was first used on:
+// reusing the same key against a different checkout is a conflict (409), not a
+// silent replay of the first checkout's response.
+test("an idempotency key is scoped to the checkout (cancel)", async () => {
+  const app = buildFullApp();
+  const a = await newCheckout(app);
+  const b = await newCheckout(app);
+  const key = "shared-cancel-key";
+  const first = await app.request(`/checkout-sessions/${a.id}/cancel`, {
+    method: "POST",
+    headers: { ...JSON_HEADERS, "Idempotency-Key": key },
+  });
+  const second = await app.request(`/checkout-sessions/${b.id}/cancel`, {
+    method: "POST",
+    headers: { ...JSON_HEADERS, "Idempotency-Key": key },
+  });
+  assert.equal(first.status, 200);
+  assert.equal(
+    second.status,
+    409,
+    "reusing a key to cancel a different checkout must conflict, not replay"
+  );
+});
+
+test("an idempotency key is scoped to the checkout (update)", async () => {
+  const app = buildFullApp();
+  const a = await newCheckout(app);
+  const b = await newCheckout(app);
+  const key = "shared-update-key";
+  const first = await app.request(`/checkout-sessions/${a.id}`, {
+    method: "PUT",
+    headers: { ...JSON_HEADERS, "Idempotency-Key": key },
+    body: JSON.stringify(BODY),
+  });
+  const second = await app.request(`/checkout-sessions/${b.id}`, {
+    method: "PUT",
+    headers: { ...JSON_HEADERS, "Idempotency-Key": key },
+    body: JSON.stringify(BODY),
+  });
+  assert.equal(first.status, 200);
+  assert.equal(
+    second.status,
+    409,
+    "reusing a key to update a different checkout must conflict, not replay"
+  );
 });


### PR DESCRIPTION
# Description

The Node.js sample keyed idempotency records only by the `Idempotency-Key` header and fingerprinted the request body alone, so **the same key reused against a different checkout (or a different operation) replayed the first response instead of conflicting**. This was most severe for `cancel`, whose hash was always the empty body, so any two cancels sharing a key were treated as identical regardless of target.

**Repro:** create two checkouts A and B, then cancel both with the same `Idempotency-Key` → the second cancel returns **200** with A's canceled checkout (silent replay) instead of conflicting.

**Root cause** — `rest/nodejs/src/api/checkout.ts`, `computeHash(data)`: the fingerprint was the body only (cancel: `{}`), with no operation or target checkout.

**Fix:** include the operation and, for `update`/`complete`/`cancel`, the target checkout id in the fingerprint — `computeHash(operation, data, resourceId?)`. This mirrors the Python sample (#166): `create` is keyed by body, `update`/`complete`/`cancel` additionally by the path checkout id, so a key can neither cross checkouts nor cross operations.

## Category (Required)

- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)

## Related Issues

None — parity with the Python sample's idempotency scoping landed in #166.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable). — *N/A, no documentation changes.*
- [x] My changes pass all local linting and formatting checks. (`tsc --noEmit` clean; `prettier` clean.)
- [x] I have added tests that prove my fix is effective or that my feature works. (`an idempotency key is scoped to the checkout (cancel)` and `…(update)` — both fail before the fix, pass after.)
- [x] New and existing unit tests pass locally with my changes. (Node.js suite: 118 passed.)
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas. — *N/A, no schema changes.*
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk. — *N/A, no schema changes.*

## Screenshots / Logs (if applicable)

Before/after — reusing one `Idempotency-Key` against two different checkouts:

**Before (bug):**
```
cancel A (key=k) -> 200
cancel B (key=k) -> 200   # replayed A's canceled checkout
```

**After (fix):**
```
cancel A (key=k) -> 200
cancel B (key=k) -> 409   # Idempotency key reused with different parameters
```

Full Node.js suite:
```
# tests 118
# pass 118
# fail 0
```
