### PR TITLE
fix(rest/nodejs): retry transient webhook failures

### DIFF
--- a/rest/nodejs/src/api/checkout.ts
+++ b/rest/nodejs/src/api/checkout.ts
@@ -160,21 +160,48 @@ export class CheckoutService {
     }
 
     const webhookUrl = checkout.platform.webhook_url;
+    const body = JSON.stringify(orderData);
+    const headers = {
+      "Content-Type": "application/json",
+      "X-Event-Type": eventType,
+      "Webhook-Id": uuidv4(),
+      "Webhook-Timestamp": Math.floor(Date.now() / 1000).toString(),
+    };
+    const maxAttempts = 3;
 
-    try {
-      await fetch(webhookUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Event-Type": eventType,
-          "Webhook-Id": uuidv4(),
-          "Webhook-Timestamp": Math.floor(Date.now() / 1000).toString(),
-        },
-        body: JSON.stringify(orderData),
-      });
-    } catch (e) {
-      console.error(`Failed to notify webhook at ${webhookUrl}`, e);
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        const response = await fetch(webhookUrl, {
+          method: "POST",
+          headers,
+          body,
+        });
+        if (response.ok) {
+          return;
+        }
+        if (response.status < 500) {
+          console.error(
+            `Webhook at ${webhookUrl} rejected delivery with status ${response.status}`
+          );
+          return;
+        }
+      } catch (e) {
+        if (attempt === maxAttempts) {
+          console.error(`Failed to notify webhook at ${webhookUrl}`, e);
+          return;
+        }
+      }
+
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, 100 * 2 ** (attempt - 1))
+        );
+      }
     }
+
+    console.error(
+      `Failed to notify webhook at ${webhookUrl} after ${maxAttempts} attempts`
+    );
   }
 
   private addressesMatch(

--- a/rest/nodejs/test/webhook.test.ts
+++ b/rest/nodejs/test/webhook.test.ts
@@ -82,7 +82,8 @@ type CapturedRequest = {
 // mirroring the delivered wire request exactly.
 async function notifyAndCapture(
   checkout: unknown,
-  eventType: string
+  eventType: string,
+  responseOutcomes: Array<number | Error> = [200]
 ): Promise<CapturedRequest[]> {
   const captured: CapturedRequest[] = [];
   const originalFetch = globalThis.fetch;
@@ -97,7 +98,11 @@ async function notifyAndCapture(
       headers,
       body: typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody,
     });
-    return new Response(null, { status: 200 });
+    const outcome = responseOutcomes[captured.length - 1] ?? 200;
+    if (outcome instanceof Error) {
+      throw outcome;
+    }
+    return new Response(null, { status: outcome });
   }) as typeof globalThis.fetch;
 
   try {
@@ -177,6 +182,73 @@ test("webhook delivers the bare order object as the body", async () => {
     undefined,
     "body must not nest the order under 'order'"
   );
+});
+
+function checkoutWithOrder() {
+  return {
+    id: CHECKOUT_ID,
+    platform: { webhook_url: WEBHOOK_URL },
+    order: {
+      id: ORDER_ID,
+      permalink_url: `http://localhost:8080/orders/${ORDER_ID}`,
+    },
+  };
+}
+
+test("webhook retries a 5xx response and preserves event identity", async () => {
+  seedOrder();
+
+  const captured = await notifyAndCapture(
+    checkoutWithOrder(),
+    "order_placed",
+    [500, 200]
+  );
+
+  assert.equal(captured.length, 2);
+  assert.equal(
+    captured[1]!.headers["Webhook-Id"],
+    captured[0]!.headers["Webhook-Id"]
+  );
+  assert.equal(
+    captured[1]!.headers["Webhook-Timestamp"],
+    captured[0]!.headers["Webhook-Timestamp"]
+  );
+  assert.deepEqual(captured[1]!.body, captured[0]!.body);
+});
+
+test("webhook retries after a transport error", async () => {
+  seedOrder();
+
+  const captured = await notifyAndCapture(checkoutWithOrder(), "order_placed", [
+    new TypeError("connection reset"),
+    200,
+  ]);
+
+  assert.equal(captured.length, 2);
+});
+
+test("webhook retries are bounded after repeated 5xx responses", async () => {
+  seedOrder();
+
+  const captured = await notifyAndCapture(
+    checkoutWithOrder(),
+    "order_placed",
+    [500, 502, 503]
+  );
+
+  assert.equal(captured.length, 3);
+});
+
+test("webhook does not retry a permanent 4xx rejection", async () => {
+  seedOrder();
+
+  const captured = await notifyAndCapture(
+    checkoutWithOrder(),
+    "order_placed",
+    [400]
+  );
+
+  assert.equal(captured.length, 1);
 });
 
 test("no webhook is delivered when there is no order", async () => {


### PR DESCRIPTION
## Description

`notifyWebhook` treated every resolved `fetch` call as a successful delivery, so a `5xx` response was silently dropped. Transport failures were logged once without retrying, even though the same event could be delivered safely with its original identity.

**Fix:** retry transport errors and `5xx` responses up to three times with exponential backoff. Permanent `4xx` responses are not retried, and all attempts reuse the same `Webhook-Id`, `Webhook-Timestamp`, and serialized body.

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [ ] **Documentation**
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [ ] **SDK**
- [x] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have included/updated the relevant JSON schemas (Core/Capability only).
- [ ] I have regenerated Python Pydantic models (not applicable).

## Screenshots / Logs (if applicable)

- `npm test`: 123 passed
- `npm run build`: passed
- `pre-commit run --all-files`: passed