### PR TITLE
fix(rest/python): emit schema-valid shipping events

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -460,6 +460,64 @@ class IntegrationTest(absltest.TestCase):
       # 2 - 2 = 0
       self.assertEqual(qty_tulip, 0, "Tulip inventory should be 0 (2 - 2)")
 
+  def test_shipping_event_matches_order_schema(self) -> None:
+    """Simulated shipping persists a schema-valid fulfillment event."""
+    with self.client:
+      payload = self._create_checkout_payload(
+        "shipping_event",
+        [
+          ("rose", "Red Rose", 1000, 2),
+          ("tulip", "White Tulip", 800, 1),
+        ],
+      )
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(
+          idempotency_key="shipping_event_1", request_id="shipping_event_1"
+        ),
+        json=payload.model_dump(mode="json", exclude_none=True),
+      )
+      self.assertEqual(response.status_code, 201, response.text)
+      checkout_sid = self.get_resource_id(response.json()["id"])
+
+      response = self.client.post(
+        f"/checkout-sessions/{checkout_sid}/complete",
+        headers=self._get_headers(
+          idempotency_key="shipping_event_2", request_id="shipping_event_2"
+        ),
+        json=self._create_payment_payload(),
+      )
+      self.assertEqual(response.status_code, 200, response.text)
+      order_id = response.json()["order"]["id"]
+
+      headers = self._get_headers()
+      headers["Simulation-Secret"] = FLAGS.simulation_secret
+      response = self.client.post(
+        f"/testing/simulate-shipping/{order_id}", headers=headers
+      )
+      self.assertEqual(response.status_code, 200, response.text)
+
+      response = self.client.get(
+        f"/orders/{order_id}", headers=self._get_headers()
+      )
+      self.assertEqual(response.status_code, 200, response.text)
+      order_data = response.json()
+      Order.model_validate(order_data)
+      event = order_data["fulfillment"]["events"][-1]
+      self.assertNotIn("timestamp", event)
+      self.assertEqual(event["type"], "shipped")
+      self.assertIn("occurred_at", event)
+      self.assertEqual(
+        event["line_items"],
+        [
+          {
+            "id": line_item["id"],
+            "quantity": line_item["quantity"]["total"],
+          }
+          for line_item in order_data["line_items"]
+        ],
+      )
+
   def test_missing_ucp_agent_header(self) -> None:
     """Tests that requests missing mandatory headers are rejected."""
     with self.client:

--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -896,13 +896,21 @@ class CheckoutService:
       order_data["fulfillment"]["events"] = []
 
     event_id = f"evt_{uuid.uuid4()}"
-    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    occurred_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    line_items = [
+      {
+        "id": line_item["id"],
+        "quantity": line_item["quantity"]["total"],
+      }
+      for line_item in order_data["line_items"]
+    ]
 
     order_data["fulfillment"]["events"].append(
       {
         "id": event_id,
         "type": "shipped",
-        "timestamp": timestamp,
+        "occurred_at": occurred_at,
+        "line_items": line_items,
       }
     )
 


### PR DESCRIPTION
## Description

`ship_order` persisted fulfillment events with a non-schema `timestamp` field and omitted the required `occurred_at` and `line_items` fields. Orders returned after simulated shipping therefore failed validation against the generated `Order` model.

**Fix:** emit `occurred_at` and an event line-item projection containing each order line-item ID and total quantity. The integration test exercises the public simulation endpoint and validates the resulting order with `Order.model_validate`.

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [ ] **Documentation**
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [ ] **SDK**
- [x] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have included/updated the relevant JSON schemas (Core/Capability only).
- [ ] I have regenerated Python Pydantic models (not applicable).

## Screenshots / Logs (if applicable)

- Python server test suite: 137 passed
- `pre-commit run --all-files`: passed