### PR TITLE
fix(rest/nodejs): log invalid validation payloads

### DIFF
--- a/rest/nodejs/src/utils/validation.ts
+++ b/rest/nodejs/src/utils/validation.ts
@@ -35,7 +35,12 @@ const formatPath = (path: (string | number)[]) => {
 export function prettyValidation<T>(
   result:
     | { success: true; data: T; target: string }
-    | { success: false; error: z.ZodError },
+    | {
+        success: false;
+        data: T;
+        target: string;
+        error: z.ZodError;
+      },
   c: Context
 ) {
   if (result.success) {
@@ -45,7 +50,7 @@ export function prettyValidation<T>(
   } else {
     c.var.logger.warn("Request payload failed validation");
     c.var.logger.warn(
-      `Request payload:\n${JSON.stringify(c.req.json(), null, 2)}`
+      `Request payload:\n${JSON.stringify(result.data, null, 2)}`
     );
     const prettyError = result.error.issues
       .map((issue) => {

--- a/rest/nodejs/test/validation.test.ts
+++ b/rest/nodejs/test/validation.test.ts
@@ -15,7 +15,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { IdParamSchema } from "../src/utils/validation";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import * as z from "zod";
+
+import { IdParamSchema, prettyValidation } from "../src/utils/validation";
 
 test("accepts a required route ID", () => {
   const result = IdParamSchema.safeParse({ id: "item-123" });
@@ -30,4 +34,35 @@ test("rejects a missing route ID", () => {
   const result = IdParamSchema.safeParse({});
 
   assert.equal(result.success, false);
+});
+
+test("logs the request payload when JSON validation fails", async () => {
+  const logLines: string[] = [];
+  const logger = {
+    info: (message: string) => logLines.push(String(message)),
+    warn: (message: string) => logLines.push(String(message)),
+  } as unknown as typeof console;
+  const app = new Hono<{ Variables: { logger: typeof console } }>();
+  app.use(async (c, next) => {
+    c.set("logger", logger);
+    await next();
+  });
+  app.post(
+    "/items",
+    zValidator("json", z.object({ quantity: z.number() }), prettyValidation),
+    (c) => c.text("created", 201)
+  );
+
+  const response = await app.request("/items", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ request_id: "invalid-payload-marker" }),
+  });
+
+  assert.equal(response.status, 422);
+  const payloadLog = logLines.find((line) =>
+    line.startsWith("Request payload:\n")
+  );
+  assert.match(payloadLog ?? "", /"request_id": "invalid-payload-marker"/);
+  assert.notEqual(payloadLog, "Request payload:\n{}");
 });


### PR DESCRIPTION
## Description

`prettyValidation` logged failed JSON validation payloads with:

```ts
JSON.stringify(c.req.json(), null, 2)
```

`c.req.json()` returns a Promise, and stringifying that Promise produces `{}`. The warning therefore omitted the invalid request body that it was intended to show.

**Fix:** serialize the parsed request value already provided as `result.data` by `@hono/zod-validator`, and cover the failure path with a regression test that preserves the existing 422 response.

## Category (Required)

- [ ] **Core Protocol**: Changes to the core UCP specification. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: Changes to a UCP capability. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD or repository infrastructure changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency or repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Changes to organization community health files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under python_sdk (not applicable).

## Screenshots / Logs (if applicable)

- `npm test`: 120 passed
- `npm run build`: passed
- `pre-commit run --all-files`: passed