### PR TITLE
fix(rest/nodejs): include line items in shipped events

### DIFF
--- a/rest/nodejs/src/api/checkout.ts
+++ b/rest/nodejs/src/api/checkout.ts
@@ -1080,7 +1080,10 @@ export class CheckoutService {
       id: `evt_${uuidv4()}`,
       type: "shipped",
       occurred_at: new Date(),
-      line_items: [],
+      line_items: order.line_items.map((lineItem) => ({
+        id: lineItem.id,
+        quantity: lineItem.quantity.total,
+      })),
     });
 
     saveOrder(order.id, order);

--- a/rest/nodejs/test/fulfillment.test.ts
+++ b/rest/nodejs/test/fulfillment.test.ts
@@ -19,7 +19,12 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 
 import { CheckoutService } from "../src/api/checkout";
-import { getProductsDb, getTransactionsDb, initDbs } from "../src/data/db";
+import {
+  getOrder,
+  getProductsDb,
+  getTransactionsDb,
+  initDbs,
+} from "../src/data";
 import {
   CheckoutCompleteRequestSchema,
   ExtendedCheckoutCreateRequestSchema,
@@ -278,6 +283,41 @@ test("a checkout with fulfillment fully selected can be completed", async () => 
   const body = (await res.json()) as Checkout;
   assert.equal(body.status, "completed");
   assert.ok(body.order?.id, "completion must assign an order id");
+});
+
+test("shipping an order includes its line items in the fulfillment event", async () => {
+  const app = buildApp();
+  const created = await createWithDestination(app);
+  const options = created.fulfillment!.methods![0].groups![0].options!;
+
+  const selectRes = await selectOption(app, created, options[0].id);
+  assert.equal(selectRes.status, 200);
+
+  const completeRes = await app.request(
+    `/checkout-sessions/${created.id}/complete`,
+    {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(SUCCESS_PAYMENT),
+    }
+  );
+  assert.equal(completeRes.status, 200);
+  const completed = (await completeRes.json()) as Checkout;
+  assert.ok(completed.order?.id, "completion must assign an order id");
+
+  await new CheckoutService().shipOrder(completed.order.id);
+
+  const order = getOrder(completed.order.id);
+  assert.ok(order, "completed order must be persisted");
+  const event = order.fulfillment.events?.at(-1);
+  assert.equal(event?.type, "shipped");
+  assert.deepEqual(
+    event?.line_items,
+    order.line_items.map((lineItem) => ({
+      id: lineItem.id,
+      quantity: lineItem.quantity.total,
+    }))
+  );
 });
 
 test("empty fulfillment methods array blocks completion", async () => {


### PR DESCRIPTION
## Summary
- Populate Node shipped fulfillment events with the shipped order line item ids and quantities instead of an empty array.
- Add a fulfillment regression test that completes a checkout, ships its order, and verifies the event line item projection.

## Test plan
- [x] npm --prefix rest/nodejs test
- [x] npm --prefix rest/nodejs run build
- [x] uvx --directory . pre-commit run --files rest/nodejs/src/api/checkout.ts rest/nodejs/test/fulfillment.test.ts
- [x] git diff --check