### PR TITLE
fix(rest/python): complete webhook-test checkouts by server-assigned id

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -1070,8 +1070,12 @@ class IntegrationTest(absltest.TestCase):
         json=payload.model_dump(mode="json", exclude_none=True),
       )
       self.assertEqual(response.status_code, 201, response.text)
+      # The server assigns the checkout id (#167); the client-supplied id in
+      # the payload is not honored, so complete against the id the create
+      # response actually returned.
+      server_id = response.json()["id"]
       response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
+        f"/checkout-sessions/{server_id}/complete",
         headers=self._get_headers(
           idempotency_key=f"{checkout_id}_complete",
           request_id=f"{checkout_id}_complete",


### PR DESCRIPTION
## What broke

The Python Server Tests job is red on main since #169 merged: every webhook signing test fails with `404 RESOURCE_NOT_FOUND` at the complete step.

Root cause: an interaction between two individually-green changes, both mine. #169's `_completed_checkout` helper (written before #167 landed) creates a checkout and then completes it using the client-supplied id. #167 makes the server assign checkout ids, so on the merged tree the complete call targets an id that does not exist. Each PR passed CI when last run because the fork test job runs at review time — the combination only ever executed after both merged.

## Fix

`_completed_checkout` reads the server-assigned id from the create response and completes against it (the same adjustment #167 applied to the other integration tests).

## Verification

- On main tip `ab78116`: reproduced all webhook-test failures locally with the same 404.
- With this fix: webhook tests 11/11, **full suite 164 passed, 0 failed**, pinned pre-commit clean.

Apologies for the breakage — both halves were mine, and the lesson (re-run the suite against the merged tree when sibling PRs land between approval and merge) is taken.