### PR TITLE
fix(rest/nodejs): quote one fulfillment group per method

### DIFF
--- a/rest/nodejs/src/api/checkout.ts
+++ b/rest/nodejs/src/api/checkout.ts
@@ -359,6 +359,23 @@ export class CheckoutService {
     // Fulfillment Logic (Mock)
     if (checkout.fulfillment?.methods) {
       for (const method of checkout.fulfillment.methods) {
+        // fulfillment.md, "Business Response Behavior": with the default
+        // supports_multi_group: false the response MUST carry one group per
+        // method. Options are quoted per destination below, so a method the
+        // merchant cannot quote for — a non-shipping type, or a destination it
+        // does not serve — still reports its line items with no options rather
+        // than no group at all.
+        if (!method.groups || method.groups.length === 0) {
+          method.groups = [
+            {
+              id: `group_${uuidv4()}`,
+              // Required by fulfillment_group.json, so never left undefined.
+              line_item_ids: method.line_item_ids ?? [],
+              options: [],
+            },
+          ];
+        }
+
         if (
           method.type === "shipping" &&
           method.selected_destination_id &&
@@ -421,19 +438,9 @@ export class CheckoutService {
             }
 
             // Assign options to groups
-            if (!method.groups || method.groups.length === 0) {
-              method.groups = [
-                {
-                  id: `group_${uuidv4()}`,
-                  line_item_ids: method.line_item_ids,
-                  options,
-                },
-              ];
-            } else {
-              // Update all groups with available options
-              for (const group of method.groups) {
-                group.options = options;
-              }
+            // Update all groups with available options
+            for (const group of method.groups) {
+              group.options = options;
             }
 
             // Calculate total from selected option

--- a/rest/nodejs/test/fulfillment.test.ts
+++ b/rest/nodejs/test/fulfillment.test.ts
@@ -359,3 +359,52 @@ test("empty fulfillment methods array blocks completion", async () => {
   assert.equal(body.messages?.[0]?.code, "INVALID_REQUEST");
   assert.match(body.messages?.[0]?.content ?? "", /fulfillment/i);
 });
+
+// fulfillment.md "Business Response Behavior" requires one group per method
+// under the default supports_multi_group: false. Only shipping methods with a
+// resolvable destination used to get one, so every other method came back with
+// groups: [] — which then satisfied the completion gate via
+// [].every(...) === true, letting a checkout complete with nothing selected.
+//
+// This mock merchant quotes options for shipping only, so a pickup method it
+// cannot serve reports a group with no options and stays uncompletable. That
+// is the point: refusing is correct, and silently completing was the bug.
+// Quoting real pickup options would be a new merchant capability, not a fix.
+test("a method the merchant cannot quote options for still gets one group", async () => {
+  const app = buildApp();
+  const created = await app.request("/checkout-sessions", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({
+      currency: "USD",
+      line_items: LINE_ITEMS,
+      payment: {},
+      buyer: KNOWN_BUYER,
+      fulfillment: {
+        methods: [{ type: "pickup", selected_destination_id: "addr_1" }],
+      },
+    }),
+  });
+  assert.equal(created.status, 201);
+  const checkout = (await created.json()) as Checkout;
+  const groups = checkout.fulfillment?.methods?.[0]?.groups;
+  assert.equal(groups?.length, 1, "one group per method");
+  assert.deepEqual(
+    groups?.[0].options,
+    [],
+    "no options the merchant can quote"
+  );
+
+  // With no option selectable, completion must still be refused.
+  const res = await app.request(`/checkout-sessions/${checkout.id}/complete`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(SUCCESS_PAYMENT),
+  });
+  assert.equal(res.status, 400);
+  const body = (await res.json()) as {
+    messages?: Array<{ code?: string; content?: string }>;
+  };
+  assert.equal(body.messages?.[0]?.code, "INVALID_REQUEST");
+  assert.match(body.messages?.[0]?.content ?? "", /fulfillment/i);
+});


### PR DESCRIPTION
## Summary

Quote one fulfillment group per method, per `fulfillment.md`, so a method the
merchant cannot quote options for reports its line items with an empty option
list rather than no group at all.

## Motivation

`fulfillment.md` "Business Response Behavior" is a **MUST**:

> When `supports_multi_group: false` (default):
> * Business **MUST** consolidate all items into a **single group per method**
> * Response still uses array structure: `methods[].groups[]` with `groups.length === 1`

`recalculateTotals` only ever created that group inside
`method.type === "shipping" && method.selected_destination_id && method.destinations`,
and then only when the destination resolved to a country. Every other method —
any non-shipping type, or a shipping method whose destination the merchant does
not serve — was returned with `groups: []`.

That is also a correctness bug, not just a schema deviation. The completion gate
reads `method.groups?.every((group) => group.selected_option_id)`, and
`[].every(...)` is `true`, so such a checkout **completed** with no option ever
selected, no fulfillment charged, and an order whose `fulfillment.expectations`
was empty — the merchant had nothing telling them what to ship or where.

This is the same vacuous-truth hazard #155 fixed one level up, where the comment
already reads *"an empty methods array must not satisfy the gate via
`[].every(...) === true`"*. The nested array had no equivalent guard.

The Python reference server was never affected: `checkout_service.py` gates on
`if method.groups:`, and an empty list is falsy in Python. This change brings the
Node sample in line on that case.

## Scope

One behaviour change, in `recalculateTotals`. The completion gate is deliberately
**not** touched: once every method carries a group, the gate's existing
`selected_option_id` check is what refuses completion, and hardening it further
would add an unreachable branch. The `if (!method.groups || …)` block inside the
quoting path becomes dead and is folded into the assignment it guarded.

`line_item_ids` is seeded with `?? []` because `fulfillment_group.json` lists it
as required — a repaired group should not itself be schema-invalid.

**Known consequence, stated deliberately:** this mock merchant quotes options for
shipping only, so a `pickup` method now returns a group with `options: []` and
stays uncompletable. Refusing is the correct outcome — silently completing was
the bug — but it means the sample advertises a `pickup` method it cannot serve.
Quoting real pickup options is a new merchant capability rather than part of this
fix; happy to add it here if maintainers prefer.

## Validation

`npm test` 134 passed / 0 failed (133 before). `tsc --noEmit` exit 0.
`prettier --check` clean.

The new test fails against `main` with `expected: 1, actual: 0` — no group is
produced — and passes with the change.

Totals were diffed across create / option-selection / completion, pickup,
multi-method, unknown buyer, no destination, digital-only, empty methods, and a
PUT without fulfillment: **no `totals` value changes**. The only response
difference is `groups: []` becoming a single group carrying the method's line
items.
