### PR TITLE
docs(rest/python): clarify webhook extension header

### DIFF
--- a/rest/python/server/services/checkout_service.py
+++ b/rest/python/server/services/checkout_service.py
@@ -842,10 +842,10 @@ class CheckoutService:
     """Notifies the configured webhook of an order event.
 
     Per the UCP REST OpenAPI (``webhooks.orderEvent``), the request body is the
-    order object itself (``#/components/schemas/order``); the event type is
-    conveyed out of band in the ``X-Event-Type`` header. The body must always
-    be a valid order, so no notification is sent when there is no order to
-    deliver.
+    order object itself (``#/components/schemas/order``). This sample also sends
+    an ``X-Event-Type`` extension header, but it is not part of the UCP webhook
+    contract and conforming receivers cannot require it. The body must always be
+    a valid order, so no notification is sent when there is no order to deliver.
 
     Every delivery is RFC 9421-signed as this business (order.md, Webhook
     Signature Verification): ``UCP-Agent`` names our profile, and


### PR DESCRIPTION
## Description

`CheckoutService._notify_webhook()` correctly describes the webhook body as the
full Order entity, but attributes the sample's `X-Event-Type` header to the UCP
REST OpenAPI:

```python
# current wording
the event type is conveyed out of band in the ``X-Event-Type`` header
```

`webhooks.orderEvent` and the Order Event Webhook specification require
`Webhook-Id` and `Webhook-Timestamp`; neither declares `X-Event-Type`. The header
is a sample extension, so the existing wording can lead implementers to require
a field that conforming Businesses do not send.

**Fix:** identify `X-Event-Type` as a sample-specific extension and clarify that
conforming receivers cannot require it. Runtime delivery behavior is unchanged.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — docstring-only correction. Ruff, formatting, all pre-commit hooks, and
`git diff --check` pass.
