### PR TITLE
docs(rest/python): fix UCP-Agent curl quoting

### DIFF
--- a/rest/python/server/README.md
+++ b/rest/python/server/README.md
@@ -325,7 +325,7 @@ Run this command against the server to create a checkout session.
 
 ```shell
 curl -X POST http://localhost:8182/checkout-sessions \
-  -H "UCP-Agent: profile="https://agent.example/profile"" \
+  -H 'UCP-Agent: profile="https://agent.example/profile"' \
   -H "request-signature: test" \
   -H "idempotency-key: a8ef6b00-b947-4eab-aa27-2e43bc93177b" \
   -H "request-id: 31530b95-2350-416f-a974-9429e0ff0663" \
@@ -516,7 +516,7 @@ checkout session.
 # Replace with your existing Checkout ID CHECKOUT_ID="600b32d3-6f67-4444-ae77-4379277fd0c7"
 
 curl -X PUT http://localhost:8182/checkout-sessions/$CHECKOUT_ID \
-  -H "UCP-Agent: profile="https://agent.example/profile"" \
+  -H 'UCP-Agent: profile="https://agent.example/profile"' \
   -H "request-signature: test" \
   -H "idempotency-key: 90ea35bd-636a-40ef-8f20-cd67c4c6f7e9" \
   -H "request-id: c6b6f52c-faa7-46c5-a4c5-7a6ed7cc5ad9" \


### PR DESCRIPTION
## Description

Two curl examples in `rest/python/server/README.md` nested unescaped double
quotes around the `UCP-Agent` header:

```shell
-H "UCP-Agent: profile="https://agent.example/profile"" \
```

The shell closes the outer string before the profile URL, so copying the command
does not pass the documented header value as one argument. The Python client's
existing `happy_path_dialog.md` example already uses the correct quoting form.

**Fix:** wrap each full header argument in single quotes while preserving the
double-quoted profile URL.

## Category (Required)

- [ ] **Core Protocol**: Changes to the core UCP protocol. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: New or updated UCP capabilities. (Requires Maintainer approval)
- [x] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, and repository infrastructure. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency and repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization-wide community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and the project's style guidelines.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`.

## Screenshots / Logs (if applicable)

- Shell argument parsing confirms the corrected header remains a single `-H` value.
- `pre-commit run --all-files`: passed.
- `git diff --check`: passed.
