### PR TITLE
fix(rest/nodejs): answer simulate-shipping order-not-found with the UCP error envelope

### DIFF
--- a/rest/nodejs/src/api/testing.ts
+++ b/rest/nodejs/src/api/testing.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ResourceNotFoundError, ucpErrorResponse } from "../utils/ucp_error";
 import { type IdParamContext } from "../utils/validation";
 import { CheckoutService } from "./checkout";
 
@@ -33,7 +34,13 @@ export class TestingService {
       return c.json({ status: "shipped" }, 200);
     } catch (e: any) {
       if (e.message === "Order not found") {
-        return c.json({ detail: "Order not found" }, 404);
+        // The Python reference answers this with the UCP error envelope
+        // (services/checkout_service.py ship_order raises
+        // ResourceNotFoundError -> server.py ucp_exception_handler).
+        return ucpErrorResponse(
+          c,
+          new ResourceNotFoundError("Order not found")
+        );
       }
       return c.json({ detail: e.message }, 500);
     }

--- a/rest/nodejs/test/error_envelope.test.ts
+++ b/rest/nodejs/test/error_envelope.test.ts
@@ -19,6 +19,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 
 import { CheckoutService } from "../src/api/checkout";
+import { TestingService } from "../src/api/testing";
 import { getProductsDb, getTransactionsDb, initDbs } from "../src/data/db";
 import {
   CheckoutCompleteRequestSchema,
@@ -66,6 +67,12 @@ function buildApp() {
     "/checkout-sessions/:id/cancel",
     zValidator("param", IdParamSchema, prettyValidation),
     svc.cancelCheckout
+  );
+  const testingSvc = new TestingService(svc);
+  app.post(
+    "/testing/simulate-shipping/:id",
+    zValidator("param", IdParamSchema, prettyValidation),
+    testingSvc.shipOrder
   );
   return app;
 }
@@ -163,6 +170,26 @@ test("idempotency conflict answers 409 with an IDEMPOTENCY_CONFLICT envelope", a
 test("unknown checkout id answers 404 with a RESOURCE_NOT_FOUND envelope", async () => {
   const app = buildApp();
   const res = await app.request("/checkout-sessions/no_such_session");
+  assert.equal(res.status, 404);
+  assertUcpError((await res.json()) as UcpErrorBody, "RESOURCE_NOT_FOUND");
+});
+
+// The Python reference envelopes this same failure through
+// ResourceNotFoundError (services/checkout_service.py ship_order ->
+// server.py ucp_exception_handler); the Node twin answered a flat
+// { detail } until this test's fix.
+test("simulate-shipping an unknown order answers 404 with a RESOURCE_NOT_FOUND envelope", async () => {
+  const app = buildApp();
+  const res = await app.request(
+    "/testing/simulate-shipping/ord_missing_envelope",
+    {
+      method: "POST",
+      headers: {
+        "Simulation-Secret":
+          process.env.SIMULATION_SECRET || "super-secret-sim-key",
+      },
+    }
+  );
   assert.equal(res.status, 404);
   assertUcpError((await res.json()) as UcpErrorBody, "RESOURCE_NOT_FOUND");
 });


### PR DESCRIPTION
Follow-up to #174, closing the one asymmetry its review pass surfaced: the Python reference answers a simulate-shipping request for an unknown order with the UCP error envelope (services/checkout_service.py ship_order raises ResourceNotFoundError, rendered by server.py ucp_exception_handler as 404 with `ucp.status: "error"` and a `RESOURCE_NOT_FOUND` message), while the Node server answered a flat `{ detail: "Order not found" }`.

Observed (Node, before): `POST /testing/simulate-shipping/<unknown-id>` with a valid Simulation-Secret returns `404 {"detail":"Order not found"}`.
Expected (matching rest/python): `404` with the envelope `{"ucp":{"version":...,"status":"error"},"messages":[{"type":"error","code":"RESOURCE_NOT_FOUND","content":"Order not found","severity":"unrecoverable"}]}`.

One-site fix reusing #174's `ResourceNotFoundError` + `ucpErrorResponse`; test added to error_envelope.test.ts alongside the existing RESOURCE_NOT_FOUND case.

Deliberately unchanged, for parity with the Python server: the 403 Invalid Simulation Secret (Python answers a flat HTTPException detail there too), the generic 500 fallback (FastAPI default is flat), and signature.ts's structured verification detail. Enveloping those would be a two-sided change to behavior the Python server currently defines, so this PR leaves them aligned as they are.

Note: open PR #179 also touches testing.ts on the shipOrder call line; the two changes do not overlap and merge cleanly in either order.
