### PR TITLE
fix(rest/nodejs): answer validation failures with the UCP error envelope

### DIFF
--- a/rest/nodejs/src/utils/validation.ts
+++ b/rest/nodejs/src/utils/validation.ts
@@ -66,7 +66,10 @@ export function prettyValidation<T>(
     // content inside the UCP envelope. A request rejected by payload validation
     // is a protocol error like any other, so it answers in that shape; the
     // pretty diagnostic stays, as the envelope's content.
-    return ucpErrorResponse(c, new UcpError(prettyError, "INVALID_REQUEST", 422));
+    return ucpErrorResponse(
+      c,
+      new UcpError(prettyError, "INVALID_REQUEST", 422)
+    );
   }
 }
 

--- a/rest/nodejs/src/utils/validation.ts
+++ b/rest/nodejs/src/utils/validation.ts
@@ -15,6 +15,8 @@
 import { type Context, type Env } from "hono";
 import * as z from "zod";
 
+import { UcpError, ucpErrorResponse } from "./ucp_error";
+
 /**
  * Middleware to handle Zod validation results.
  * Logs the validation status and returns a 422 error with a pretty-printed message if validation fails.
@@ -60,7 +62,11 @@ export function prettyValidation<T>(
       .join("\n");
 
     c.var.logger.warn(prettyError);
-    return c.text(prettyError, 422);
+    // checkout-rest.md shapes protocol errors as a JSON body carrying code and
+    // content inside the UCP envelope. A request rejected by payload validation
+    // is a protocol error like any other, so it answers in that shape; the
+    // pretty diagnostic stays, as the envelope's content.
+    return ucpErrorResponse(c, new UcpError(prettyError, "INVALID_REQUEST", 422));
   }
 }
 

--- a/rest/nodejs/test/validation_envelope.test.ts
+++ b/rest/nodejs/test/validation_envelope.test.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 UCP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// checkout-rest.md gives protocol errors one shape: a JSON body carrying
+// code and content inside the UCP envelope. Requests rejected by payload
+// validation are protocol errors like any other, so they must speak that
+// shape too — a plain-text diagnostic gives the platform nothing to parse.
+
+import assert from "node:assert/strict";
+import { before, test } from "node:test";
+
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+
+import { CheckoutService } from "../src/api/checkout";
+import { getProductsDb, getTransactionsDb, initDbs } from "../src/data/db";
+import { ExtendedCheckoutCreateRequestSchema } from "../src/models";
+import { UCP_VERSION } from "../src/utils/config";
+import { prettyValidation } from "../src/utils/validation";
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+function buildApp() {
+  const service = new CheckoutService();
+  const app = new Hono<{ Variables: { logger: typeof console } }>();
+  app.use(async (c, next) => {
+    c.set("logger", console);
+    await next();
+  });
+  app.post(
+    "/checkout-sessions",
+    zValidator("json", ExtendedCheckoutCreateRequestSchema, prettyValidation),
+    service.createCheckout
+  );
+  return app;
+}
+
+before(() => {
+  initDbs(":memory:", ":memory:");
+  getProductsDb()
+    .prepare(
+      "INSERT INTO products (id, title, price, image_url) VALUES (?, ?, ?, ?)"
+    )
+    .run("bouquet_roses", "Red Rose", 3500, "");
+  getTransactionsDb()
+    .prepare("INSERT INTO inventory (product_id, quantity) VALUES (?, ?)")
+    .run("bouquet_roses", 100);
+});
+
+async function create(app: ReturnType<typeof buildApp>, body: object) {
+  return app.request("/checkout-sessions", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+test("validation failure answers with the UCP error envelope, not plain text", async () => {
+  const app = buildApp();
+  const res = await create(app, { line_items: "not-an-array" });
+  assert.equal(res.status, 422);
+  assert.match(
+    res.headers.get("content-type") ?? "",
+    /application\/json/,
+    "validation errors must be JSON, not text"
+  );
+  const body = await res.json();
+  assert.equal(body.ucp?.status, "error", "ucp.status must be 'error'");
+  assert.equal(body.ucp?.version, UCP_VERSION);
+  assert.ok(
+    Array.isArray(body.messages) && body.messages.length > 0,
+    "messages[] must carry the failure"
+  );
+  const msg = body.messages[0];
+  assert.equal(msg.type, "error");
+  assert.ok(msg.code, "code must be present");
+  assert.ok(
+    typeof msg.content === "string" && msg.content.includes("line_items"),
+    "content must name the offending member"
+  );
+});
+
+test("a valid create still succeeds after the envelope change", async () => {
+  const app = buildApp();
+  const res = await create(app, {
+    line_items: [{ item: { id: "bouquet_roses" }, quantity: 1 }],
+  });
+  assert.equal(res.status, 201);
+});


### PR DESCRIPTION
## What

A request rejected by payload validation draws a plain text 422 built from the raw zod issues. A validation failure is the only rejection this server still answers as plain text, and the checkout error taxonomy has answered with the UCP envelope since #174. `shopping/checkout/rest.md` gives protocol errors one shape, a JSON body carrying code and content, so a platform can act on the rejection.

    POST /checkout-sessions
    {"line_items": "not-an-array"}

    HTTP 422  content-type: text/plain
    ✖ Expected array, received string
      → at line_items

## Fix

prettyValidation keeps building the same readable diagnostic and now renders it through the existing ucpErrorResponse helper as INVALID_REQUEST with status 422, so the envelope carries the diagnostic as content. Log output is unchanged.

## Testing

- New test/validation_envelope.test.ts: a validation failure must answer application/json in the UCP envelope shape with the offending member named in content, and a valid create still returns 201. The envelope test fails on main and passes with the fix; the suite is 156 passing with it (re-measured 2026-09-01 on a test merge into main `00333a8`: 156 passing, 0 failing, against 154 on main).
- Sweep: a schema guided sweep of 261 request mutations drew 122 plain text rejections on main and zero after this change, with no other bucket moving.

