### PR TITLE
fix(rest/python): answer validation failures with the UCP error envelope

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -1530,6 +1530,53 @@ class IntegrationTest(absltest.TestCase):
       self.assertEqual(response.status_code, 201, f"Response: {response.text}")
       self.assertIsInstance(response.json().get("id"), str)
 
+  def test_validation_failure_answers_with_ucp_envelope(self) -> None:
+    """A validation failure answers with the UCP envelope, not detail."""
+    with self.client:
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(
+          idempotency_key="val_err_1", request_id="val_err_1"
+        ),
+        json={"line_items": "not-an-array"},
+      )
+      self.assertEqual(response.status_code, 422)
+      self.assertIn(
+        "application/json", response.headers.get("content-type", "")
+      )
+      data = response.json()
+      self.assertNotIn("detail", data, "flat detail shape must be gone")
+      self.assertEqual(
+        data.get("ucp", {}).get("status"), "error", "ucp.status must be 'error'"
+      )
+      self.assertEqual(data.get("ucp", {}).get("version"), app.version)
+      messages = data.get("messages", [])
+      self.assertTrue(
+        isinstance(messages, list) and len(messages) > 0,
+        "messages[] must carry the failure",
+      )
+      msg = messages[0]
+      self.assertEqual(msg.get("type"), "error")
+      self.assertEqual(msg.get("code"), "INVALID_REQUEST")
+      self.assertEqual(msg.get("severity"), "unrecoverable")
+      self.assertIn(
+        "line_items",
+        msg.get("content", ""),
+        "content must name the offending member",
+      )
+
+  def test_valid_create_succeeds_after_envelope_change(self) -> None:
+    """A valid checkout creation still succeeds after the change."""
+    with self.client:
+      response = self.client.post(
+        "/checkout-sessions",
+        headers=self._get_headers(
+          idempotency_key="val_ok_1", request_id="val_ok_1"
+        ),
+        json={"line_items": [{"item": {"id": "rose"}, "quantity": 1}]},
+      )
+      self.assertEqual(response.status_code, 201, f"Response: {response.text}")
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/rest/python/server/server.py
+++ b/rest/python/server/server.py
@@ -22,6 +22,7 @@ import config
 from exceptions import UcpError
 from fastapi import FastAPI
 from fastapi import Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 import generated_routes.ucp_routes
 from routes.discovery import router as discovery_router
@@ -41,6 +42,57 @@ app = FastAPI(
   description="Reference implementation of the UCP Shopping Service",
   lifespan=config.lifespan,
 )
+
+
+def _format_validation_loc(loc: tuple[int | str, ...]) -> str:
+  parts = list(loc)
+  if parts and parts[0] in ("body", "query", "path", "header"):
+    parts = parts[1:]
+  if not parts:
+    return str(loc[0]) if loc else "request"
+  path = ""
+  for p in parts:
+    if isinstance(p, int):
+      path += f"[{p}]"
+    else:
+      path = f"{path}.{p}" if path else str(p)
+  return path
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(
+  request: Request, exc: RequestValidationError
+):
+  """Handle validation errors and convert to the UCP error envelope."""
+  del request  # Unused.
+  error_lines = []
+  for err in exc.errors():
+    path = _format_validation_loc(err.get("loc", ()))
+    msg = err.get("msg", "Validation error")
+    error_lines.append(f"✖ {msg}\n  → at {path}")
+
+  error_content = (
+    "\n".join(error_lines) if error_lines else "Request validation failed."
+  )
+  logger.warning("Request payload failed validation:\n%s", error_content)
+
+  return JSONResponse(
+    status_code=422,
+    content={
+      "ucp": {
+        "version": config.get_server_version(),
+        "status": "error",
+      },
+      "messages": [
+        {
+          "type": "error",
+          "code": "INVALID_REQUEST",
+          "content": error_content,
+          "severity": "unrecoverable",
+        }
+      ],
+    },
+  )
 
 
 @app.exception_handler(UcpError)


### PR DESCRIPTION
# Description

Handles FastAPI / Pydantic validation errors (`RequestValidationError`) in the Python reference server by rendering them in the UCP error envelope (`ucp.status: "error"` with `messages[]` carrying `INVALID_REQUEST` and status 422), matching the Node.js implementation from #192.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Fixes #195

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

```http
POST /checkout-sessions HTTP/1.1
UCP-Agent: profile="https://agent.example/profile"
Content-Type: application/json

{"line_items": "not-an-array"}
```

Response:
```http
HTTP/1.1 422 Unprocessable Entity
Content-Type: application/json

{
  "ucp": {
    "version": "2026-01-23",
    "status": "error"
  },
  "messages": [
    {
      "type": "error",
      "code": "INVALID_REQUEST",
      "content": "✖ Input should be a valid list\n  → at line_items",
      "severity": "unrecoverable"
    }
  ]
}
```
