### PR TITLE
docs: fix python sample spec URLs

### DIFF
--- a/rest/python/server/README.md
+++ b/rest/python/server/README.md
@@ -195,7 +195,7 @@ Response:
     "services": {
       "dev.ucp.shopping": {
         "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping",
+        "spec": "https://ucp.dev/2026-04-08/specification/overview",
         "rest": {
           "schema": "https://ucp.dev/2026-04-08/services/shopping/openapi.json",
           "endpoint": "http://localhost:8182/"
@@ -208,21 +208,21 @@ Response:
     "capabilities": [
       {
         "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping/checkout",
+        "spec": "https://ucp.dev/2026-04-08/specification/checkout",
         "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json",
         "extends": null,
         "config": null
       },
       {
         "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping/discount",
+        "spec": "https://ucp.dev/2026-04-08/specification/discount",
         "schema": "https://ucp.dev/2026-04-08/schemas/shopping/discount.json",
         "extends": "dev.ucp.shopping.checkout",
         "config": null
       },
       {
         "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping/fulfillment",
+        "spec": "https://ucp.dev/2026-04-08/specification/fulfillment",
         "schema": "https://ucp.dev/2026-04-08/schemas/shopping/fulfillment.json",
         "extends": "dev.ucp.shopping.checkout",
         "config": null


### PR DESCRIPTION
## Description

The Python sample README's discovery profile example pointed several `spec`
URLs at paths that do not exist on the published UCP site:

```json
"spec": "https://ucp.dev/2026-04-08/specification/shopping/checkout"
```

The sample server's actual discovery profile uses the reachable paths without
the extra `shopping` segment (and `overview` for the service entry). The old
example URLs return 404, while the updated URLs return 200.

**Fix:** align the README discovery profile example with the sample server's
runtime profile and the published spec URLs.

## Category (Required)
- [ ] **Core Protocol**: Changes to the core UCP specification. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance, contribution process, or project docs. (Requires Governance Council approval)
- [ ] **Capability**: Changes to existing or new capabilities. (Requires Maintainer approval)
- [ ] **Documentation**: General documentation updates. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, build, and repository infrastructure. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates, cleanup, and non-functional changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization-level templates and community health files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist
- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `uvx pre-commit run --all-files`
- `git diff --check`
- Verified the updated `https://ucp.dev/2026-04-08/specification/{overview,checkout,discount,fulfillment}` URLs return 200.
