### PR TITLE
fix(rest/nodejs): align discovery declarations

### DIFF
--- a/rest/nodejs/src/api/discovery.ts
+++ b/rest/nodejs/src/api/discovery.ts
@@ -140,9 +140,9 @@ export class DiscoveryService {
         "dev.ucp.shopping": [
           {
             version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping`,
+            spec: `https://ucp.dev/${this.ucpVersion}/specification/overview`,
             transport: "rest",
-            schema: `https://ucp.dev/${this.ucpVersion}/services/shopping/openapi.json`,
+            schema: `https://ucp.dev/${this.ucpVersion}/services/shopping/rest.openapi.json`,
             endpoint: new URL(c.req.url).origin,
           },
         ],
@@ -151,45 +151,21 @@ export class DiscoveryService {
         "dev.ucp.shopping.checkout": [
           {
             version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/checkout`,
+            spec: `https://ucp.dev/${this.ucpVersion}/specification/checkout`,
             schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/checkout.json`,
           },
         ],
         "dev.ucp.shopping.order": [
           {
             version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/order`,
+            spec: `https://ucp.dev/${this.ucpVersion}/specification/order`,
             schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/order.json`,
-          },
-        ],
-        "dev.ucp.shopping.refund": [
-          {
-            version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/refund`,
-            schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/refund.json`,
-            extends: "dev.ucp.shopping.order",
-          },
-        ],
-        "dev.ucp.shopping.return": [
-          {
-            version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/return`,
-            schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/return.json`,
-            extends: "dev.ucp.shopping.order",
-          },
-        ],
-        "dev.ucp.shopping.dispute": [
-          {
-            version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/dispute`,
-            schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/dispute.json`,
-            extends: "dev.ucp.shopping.order",
           },
         ],
         "dev.ucp.shopping.discount": [
           {
             version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/discount`,
+            spec: `https://ucp.dev/${this.ucpVersion}/specification/discount`,
             schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/discount.json`,
             extends: "dev.ucp.shopping.checkout",
           },
@@ -197,7 +173,7 @@ export class DiscoveryService {
         "dev.ucp.shopping.fulfillment": [
           {
             version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/fulfillment`,
+            spec: `https://ucp.dev/${this.ucpVersion}/specification/fulfillment`,
             schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/fulfillment.json`,
             extends: "dev.ucp.shopping.checkout",
           },
@@ -205,7 +181,7 @@ export class DiscoveryService {
         "dev.ucp.shopping.buyer_consent": [
           {
             version: this.ucpVersion,
-            spec: `https://ucp.dev/${this.ucpVersion}/specification/shopping/buyer_consent`,
+            spec: `https://ucp.dev/${this.ucpVersion}/specification/buyer-consent`,
             schema: `https://ucp.dev/${this.ucpVersion}/schemas/shopping/buyer_consent.json`,
             extends: "dev.ucp.shopping.checkout",
           },

--- a/rest/nodejs/test/discovery.test.ts
+++ b/rest/nodejs/test/discovery.test.ts
@@ -19,10 +19,19 @@ import { Hono } from "hono";
 
 import { DiscoveryService } from "../src/api/discovery";
 
+type DiscoveryDeclaration = {
+  version: string;
+  spec: string;
+  schema: string;
+};
+
 type DiscoveryResponse = {
   ucp: {
-    services: Record<string, Array<{ endpoint: string; transport: string }>>;
-    capabilities: Record<string, Array<{ version: string }>>;
+    services: Record<
+      string,
+      Array<DiscoveryDeclaration & { endpoint: string; transport: string }>
+    >;
+    capabilities: Record<string, DiscoveryDeclaration[]>;
   };
 };
 
@@ -41,23 +50,43 @@ test("merchant profile uses schema-compliant discovery registries", async () => 
   assert.equal(shoppingServices.length, 1);
   assert.equal(shoppingServices[0]?.transport, "rest");
   assert.equal(shoppingServices[0]?.endpoint, "http://localhost");
+  assert.equal(
+    shoppingServices[0]?.spec,
+    `https://ucp.dev/${discoveryService.ucpVersion}/specification/overview`
+  );
+  assert.equal(
+    shoppingServices[0]?.schema,
+    `https://ucp.dev/${discoveryService.ucpVersion}/services/shopping/rest.openapi.json`
+  );
 
   assert.equal(Array.isArray(body.ucp.capabilities), false);
   assert.deepEqual(Object.keys(body.ucp.capabilities).sort(), [
     "dev.ucp.shopping.buyer_consent",
     "dev.ucp.shopping.checkout",
     "dev.ucp.shopping.discount",
-    "dev.ucp.shopping.dispute",
     "dev.ucp.shopping.fulfillment",
     "dev.ucp.shopping.order",
-    "dev.ucp.shopping.refund",
-    "dev.ucp.shopping.return",
   ]);
 
+  const specSlugs: Record<string, string> = {
+    "dev.ucp.shopping.buyer_consent": "buyer-consent",
+    "dev.ucp.shopping.checkout": "checkout",
+    "dev.ucp.shopping.discount": "discount",
+    "dev.ucp.shopping.fulfillment": "fulfillment",
+    "dev.ucp.shopping.order": "order",
+  };
   for (const [name, declarations] of Object.entries(body.ucp.capabilities)) {
     assert.ok(Array.isArray(declarations), `${name} must be an array`);
     assert.equal(declarations.length, 1);
     assert.equal(declarations[0]?.version, discoveryService.ucpVersion);
+    assert.equal(
+      declarations[0]?.spec,
+      `https://ucp.dev/${discoveryService.ucpVersion}/specification/${specSlugs[name]}`
+    );
+    assert.equal(
+      declarations[0]?.schema,
+      `https://ucp.dev/${discoveryService.ucpVersion}/schemas/shopping/${name.split(".").at(-1)}.json`
+    );
   }
 });
 


### PR DESCRIPTION
## Description

`rest/nodejs/src/api/discovery.ts` advertised specification and schema URLs that do not exist in the pinned `2026-04-08` release. For example:

```text
https://ucp.dev/2026-04-08/specification/shopping/checkout -> 404
https://ucp.dev/2026-04-08/schemas/shopping/refund.json  -> 404
```

The profile also advertised refund, return, and dispute capabilities, but `v2026-04-08` has no schemas for them and the Node sample has no corresponding capability implementation.

**Fix:** use the published service/capability URLs, remove the three unsupported capability declarations, and extend the discovery regression test to assert the advertised capability set and URLs.

## Category (Required)

- [ ] **Core Protocol**: Changes to core UCP schemas, specification, or protocol behavior. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to governance documents, contribution guidelines, or project processes. (Requires Governance Council approval)
- [ ] **Capability**: New or updated capability definitions. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, build tooling, or repository automation. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates, refactoring, or non-functional changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Issue templates, code of conduct, or community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `npm test` (154/154)
- `npm run build`
- all 12 advertised `ucp.dev/2026-04-08` spec/schema URLs returned HTTP 200
- `uvx pre-commit run --all-files`
- `git diff --check`
