### PR TITLE
fix(rest/python): publish the REST OpenAPI schema URL

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -1314,6 +1314,17 @@ class IntegrationTest(absltest.TestCase):
     self.assertIn(jwk, profile.get("signing_keys", []))
     self.assertIn(jwk, profile.get("ucp", {}).get("keys", []))
 
+  def test_profile_publishes_rest_service_schema(self) -> None:
+    """The REST service points to the published OpenAPI document."""
+    with self.client:
+      profile = self.client.get("/.well-known/ucp").json()
+
+    service = profile["ucp"]["services"]["dev.ucp.shopping"][0]
+    self.assertEqual(
+      service["schema"],
+      "https://ucp.dev/2026-04-08/services/shopping/rest.openapi.json",
+    )
+
   def test_version_invalid_format(self) -> None:
     """Tests that UCP-Agent with invalid version format is rejected."""
     with self.client:

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -1320,9 +1320,10 @@ class IntegrationTest(absltest.TestCase):
       profile = self.client.get("/.well-known/ucp").json()
 
     service = profile["ucp"]["services"]["dev.ucp.shopping"][0]
+    version = profile["ucp"]["version"]
     self.assertEqual(
       service["schema"],
-      "https://ucp.dev/2026-04-08/services/shopping/rest.openapi.json",
+      f"https://ucp.dev/{version}/services/shopping/rest.openapi.json",
     )
 
   def test_version_invalid_format(self) -> None:

--- a/rest/python/server/routes/discovery_profile.json
+++ b/rest/python/server/routes/discovery_profile.json
@@ -8,7 +8,7 @@
           "spec": "https://ucp.dev/2026-04-08/specification/overview",
           "transport": "rest",
           "endpoint": "{{ENDPOINT}}",
-          "schema": "https://ucp.dev/2026-04-08/services/shopping/openapi.json"
+          "schema": "https://ucp.dev/2026-04-08/services/shopping/rest.openapi.json"
         }
       ]
     },


### PR DESCRIPTION
# Description

The Python REST sample advertises this service schema in its live discovery profile:

```json
"schema": "https://ucp.dev/2026-04-08/services/shopping/openapi.json"
```

That URL returns HTTP 404. The published `v2026-04-08` file is
`services/shopping/rest.openapi.json`, which returns HTTP 200 and matches the
REST service schema name in the UCP source tree.

**Fix:** point the Python discovery profile to the published REST OpenAPI URL
and add an integration assertion over the `/.well-known/ucp` response.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — verified the old URL returns HTTP 404 and the corrected URL returns HTTP 200. The targeted discovery profile tests (3/3), all 27 integration tests when applied with the already approved PR #196 baseline fix, and all repository pre-commit hooks pass locally. The current `main` alone has 14 payment-model mismatch errors addressed by #196; this change adds no failures and does not conflict with it.
