### PR TITLE
docs(a2a): update Node.js prerequisite

### DIFF
--- a/a2a/README.md
+++ b/a2a/README.md
@@ -69,7 +69,7 @@ The sample uses **[Google ADK](https://google.github.io/adk-docs/)** (Agent Deve
 Before you begin, ensure you have:
 
 - [ ] Python 3.13+ with [UV](https://docs.astral.sh/uv/)
-- [ ] Node.js 18+
+- [ ] Node.js 20.x (20.19+) or 22.12+
 - [ ] [Gemini API Key](https://aistudio.google.com/apikey)
 
 ### 1. Start the Cymbal Retail Agent


### PR DESCRIPTION
## Description

The A2A quick-start guide lists Node.js 18+ as sufficient for the chat client:

```markdown
- [ ] Node.js 18+
```

The committed frontend lockfile uses Vite 8.0.16, whose package metadata requires Node.js `^20.19.0 || >=22.12.0`. Following the documented prerequisite with Node 18 therefore selects a runtime outside the installed toolchain's supported range.

**Fix:** update the prerequisite to Node.js 20.x (20.19+) or 22.12+, matching the locked Vite engine.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- parsed `a2a/chat-client/package-lock.json` and verified Vite 8.0.16 requires `^20.19.0 || >=22.12.0`
- asserted the README prerequisite covers both supported Node ranges
- `uvx pre-commit run --all-files`
- `git diff --check`
