### PR TITLE
docs(a2a): fix integration guide spec links

### DIFF
--- a/a2a/docs/03-ucp-integration.md
+++ b/a2a/docs/03-ucp-integration.md
@@ -45,7 +45,7 @@ This enables any UCP-compliant client to work with any UCP-compliant merchant.
     "services": {
       "dev.ucp.shopping": {
         "version": "2026-01-23",
-        "spec": "https://ucp.dev/2026-01-23/specification/shopping",
+        "spec": "https://ucp.dev/2026-01-23/specification/overview",
         "a2a": {
           "endpoint": "http://localhost:10999/.well-known/agent-card.json"
         }
@@ -54,7 +54,7 @@ This enables any UCP-compliant client to work with any UCP-compliant merchant.
     "capabilities": [
       {
         "version": "2026-01-23",
-        "spec": "https://ucp.dev/2026-01-23/specification/shopping/checkout",
+        "spec": "https://ucp.dev/2026-01-23/specification/checkout",
         "schema": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json"
       },
       {


### PR DESCRIPTION
## Description

The A2A UCP integration guide's merchant profile example still points two
`spec` fields at the old nested shopping documentation paths:

```json
"spec": "https://ucp.dev/2026-01-23/specification/shopping"
"spec": "https://ucp.dev/2026-01-23/specification/shopping/checkout"
```

Both URLs now return 404. The same-version `overview` and `checkout` paths are
reachable, and the checkout schema URL in the example is already valid.

**Fix:** update only the two documentation `spec` links to the reachable
same-version paths while leaving the sample profile version and schema URL
unchanged.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- parsed the guide's merchant profile JSON block successfully
- verified the updated service, checkout, and checkout schema URLs return HTTP 200
- `uvx pre-commit run --all-files`
- `git diff --check`
