### PR TITLE
docs(rest/python): fix sample output spec URLs

### DIFF
--- a/rest/python/client/flower_shop/sample_output/happy_path_dialog.md
+++ b/rest/python/client/flower_shop/sample_output/happy_path_dialog.md
@@ -46,7 +46,7 @@ export RESPONSE=$(curl -s -X GET $SERVER_URL/.well-known/ucp)
     "services": {
       "dev.ucp.shopping": {
         "version": "2026-01-23",
-        "spec": "https://ucp.dev/2026-01-23/specification/shopping",
+        "spec": "https://ucp.dev/2026-01-23/specification/overview",
         "rest": {
           "schema": "https://ucp.dev/2026-01-23/services/shopping/openapi.json",
           "endpoint": "http://localhost:8182/"
@@ -56,12 +56,12 @@ export RESPONSE=$(curl -s -X GET $SERVER_URL/.well-known/ucp)
     "capabilities": [
       {
         "version": "2026-01-23",
-        "spec": "https://ucp.dev/2026-01-23/specification/shopping/checkout",
+        "spec": "https://ucp.dev/2026-01-23/specification/checkout",
         "schema": "https://ucp.dev/2026-01-23/schemas/shopping/checkout.json"
       },
       {
         "version": "2026-01-23",
-        "spec": "https://ucp.dev/2026-01-23/specification/shopping/order",
+        "spec": "https://ucp.dev/2026-01-23/specification/order",
         "schema": "https://ucp.dev/2026-01-23/schemas/shopping/order.json"
       },
       {
@@ -84,13 +84,13 @@ export RESPONSE=$(curl -s -X GET $SERVER_URL/.well-known/ucp)
       },
       {
         "version": "2026-01-23",
-        "spec": "https://ucp.dev/2026-01-23/specification/shopping/discount",
+        "spec": "https://ucp.dev/2026-01-23/specification/discount",
         "schema": "https://ucp.dev/2026-01-23/schemas/shopping/discount.json",
         "extends": "dev.ucp.shopping.checkout"
       },
       {
         "version": "2026-01-23",
-        "spec": "https://ucp.dev/2026-01-23/specification/shopping/fulfillment",
+        "spec": "https://ucp.dev/2026-01-23/specification/fulfillment",
         "schema": "https://ucp.dev/2026-01-23/schemas/shopping/fulfillment.json",
         "extends": "dev.ucp.shopping.checkout"
       },


### PR DESCRIPTION
## Description

`rest/python/client/flower_shop/sample_output/happy_path_dialog.md` still
shows five discovery `spec` URLs using the retired nested
`/specification/shopping...` paths:

```json
"spec": "https://ucp.dev/2026-01-23/specification/shopping"
"spec": "https://ucp.dev/2026-01-23/specification/shopping/checkout"
"spec": "https://ucp.dev/2026-01-23/specification/shopping/order"
"spec": "https://ucp.dev/2026-01-23/specification/shopping/discount"
"spec": "https://ucp.dev/2026-01-23/specification/shopping/fulfillment"
```

Each returns 404. The same-version `overview`, `checkout`, `order`,
`discount`, and `fulfillment` documentation paths return 200. The sample
output is copied by readers inspecting the Python client discovery response,
so these stale URLs propagate into otherwise valid example profiles.

**Fix:** replace only the five URLs with their reachable same-version paths.
The version, schema URLs, response structure, and capabilities without a
published replacement remain unchanged.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- parsed the sample output JSON block successfully
- verified each replaced URL returns HTTP 200 and each old URL returns HTTP 404
- `uvx pre-commit run --all-files`
- `git diff --check`
