### PR TITLE
docs: use PostalAddress snake_case attribute

### DIFF
--- a/a2a/docs/06-extending.md
+++ b/a2a/docs/06-extending.md
@@ -57,7 +57,7 @@ tax = int(subtotal * tax_rate)
 
 def _get_tax_rate(self, address: PostalAddress) -> float:
     state_rates = {"CA": 0.0725, "NY": 0.08, "TX": 0.0625}
-    return state_rates.get(address.addressRegion, 0.05)
+    return state_rates.get(address.address_region, 0.05)
 ```
 
 ### Add Minimum Order


### PR DESCRIPTION
## Description

The A2A extension guide's location-based tax example accesses
`PostalAddress.addressRegion`:

```python
return state_rates.get(address.addressRegion, 0.05)
```

`PostalAddress` exposes the generated Python model field as
`address_region`; the camelCase attribute raises `AttributeError` when the
example is copied into an extension.

**Fix:** use `address.address_region` in the tax-rate example.

## Category (Required)

- [ ] **Core Protocol**: Changes to the UCP core protocol. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: Changes to UCP capabilities. (Requires Maintainer approval)
- [x] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, or repository infrastructure changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency or maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Community health file changes. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

`PostalAddress(address_region="CA").address_region == "CA"`; accessing
`address.addressRegion` raises `AttributeError`. Full pre-commit and
`git diff --check` pass.
