### PR TITLE
docs: fix A2A SDK model imports

### DIFF
--- a/a2a/docs/03-ucp-integration.md
+++ b/a2a/docs/03-ucp-integration.md
@@ -154,16 +154,18 @@ def get_checkout_type(ucp_metadata: UcpMetadata) -> type[Checkout]:
 
 ```python
 # Checkout types
-from ucp_sdk.models.schemas.shopping.checkout_resp import CheckoutResponse
-from ucp_sdk.models.schemas.shopping.checkout import Checkout, FulfillmentCheckout
+from ucp_sdk.models.schemas.shopping.checkout_resp import CheckoutResponse as Checkout
+from ucp_sdk.models.schemas.shopping.fulfillment_resp import Checkout as FulfillmentCheckout
+from ucp_sdk.models.schemas.shopping.buyer_consent_resp import Checkout as BuyerConsentCheckout
+from ucp_sdk.models.schemas.shopping.discount_resp import Checkout as DiscountCheckout
 
 # Common types
-from ucp_sdk.models.schemas.shopping.types.line_item import LineItem
-from ucp_sdk.models.schemas.shopping.types.payment_response import PaymentResponse
+from ucp_sdk.models.schemas.shopping.types.line_item_resp import LineItemResponse as LineItem
+from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse
 from ucp_sdk.models.schemas.shopping.types.order_confirmation import OrderConfirmation
 
 # Fulfillment
-from ucp_sdk.models.schemas.shopping.types.fulfillment_option_response import FulfillmentOptionResponse
+from ucp_sdk.models.schemas.shopping.types.fulfillment_option_resp import FulfillmentOptionResponse
 from ucp_sdk.models.schemas.shopping.types.postal_address import PostalAddress
 ```
 


### PR DESCRIPTION
## Description

The A2A integration guide's SDK import block still uses four module paths that
do not exist in the sample's pinned `ucp-sdk==0.1.0` environment:

```python
from ucp_sdk.models.schemas.shopping.checkout import Checkout, FulfillmentCheckout
from ucp_sdk.models.schemas.shopping.types.line_item import LineItem
from ucp_sdk.models.schemas.shopping.types.payment_response import PaymentResponse
from ucp_sdk.models.schemas.shopping.types.fulfillment_option_response import FulfillmentOptionResponse
```

Copying the block fails immediately with `ModuleNotFoundError`. The business
agent already imports these response models from the generated `_resp` modules.

**Fix:** align the guide with the working imports used by `store.py`, including
the fulfillment, buyer-consent, and discount checkout aliases described by the
dynamic type example above it.

## Category (Required)

- [ ] **Core Protocol**: Changes to the UCP core protocol. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: Changes to UCP capabilities. (Requires Maintainer approval)
- [x] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, or repository infrastructure changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency or maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Community health file changes. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

The four stale modules fail to import in the pinned SDK environment. The full
replacement import set succeeds; full pre-commit and `git diff --check` pass.
