### PR TITLE
docs(rest/python): align discovery response example

### DIFF
--- a/rest/python/server/README.md
+++ b/rest/python/server/README.md
@@ -323,7 +323,9 @@ Response:
         "crv": "P-256",
         "kid": "<runtime-generated>",
         "x": "<runtime-generated>",
-        "y": "<runtime-generated>"
+        "y": "<runtime-generated>",
+        "use": "sig",
+        "alg": "ES256"
       }
     ]
   },
@@ -333,7 +335,9 @@ Response:
       "crv": "P-256",
       "kid": "<runtime-generated>",
       "x": "<runtime-generated>",
-      "y": "<runtime-generated>"
+      "y": "<runtime-generated>",
+      "use": "sig",
+      "alg": "ES256"
     }
   ]
 }

--- a/rest/python/server/README.md
+++ b/rest/python/server/README.md
@@ -193,112 +193,149 @@ Response:
   "ucp": {
     "version": "2026-04-08",
     "services": {
-      "dev.ucp.shopping": {
-        "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping",
-        "rest": {
-          "schema": "https://ucp.dev/2026-04-08/services/shopping/openapi.json",
-          "endpoint": "http://localhost:8182/"
-        },
-        "mcp": null,
-        "a2a": null,
-        "embedded": null
-      }
+      "dev.ucp.shopping": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/overview",
+          "transport": "rest",
+          "endpoint": "http://localhost:8182",
+          "schema": "https://ucp.dev/2026-04-08/services/shopping/openapi.json"
+        }
+      ]
     },
-    "capabilities": [
+    "capabilities": {
+      "dev.ucp.shopping.checkout": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/checkout",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+        }
+      ],
+      "dev.ucp.shopping.cart": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/cart",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/cart.json"
+        }
+      ],
+      "dev.ucp.shopping.order": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/order",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/order.json"
+        }
+      ],
+      "dev.ucp.shopping.discount": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/discount",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/discount.json",
+          "extends": ["dev.ucp.shopping.checkout", "dev.ucp.shopping.cart"]
+        }
+      ],
+      "dev.ucp.shopping.fulfillment": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/fulfillment",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/fulfillment.json",
+          "extends": "dev.ucp.shopping.checkout"
+        }
+      ],
+      "dev.ucp.shopping.buyer_consent": [
+        {
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/buyer-consent",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/buyer_consent.json",
+          "extends": "dev.ucp.shopping.checkout"
+        }
+      ]
+    },
+    "payment_handlers": {
+      "dev.shopify.shop_pay": [
+        {
+          "id": "shop_pay",
+          "name": "com.shopify.shop_pay",
+          "version": "2026-04-08",
+          "spec": "https://shopify.dev/docs/agents/checkout/shop-pay-handler",
+          "config_schema": "https://shopify.dev/ucp/shop-pay-handler/2026-04-08/config.json",
+          "instrument_schemas": [
+            "https://shopify.dev/ucp/shop-pay-handler/2026-04-08/instrument.json"
+          ],
+          "config": {
+            "shop_id": "<runtime-generated>"
+          }
+        }
+      ],
+      "com.google.pay": [
+        {
+          "id": "google_pay",
+          "name": "com.google.pay",
+          "version": "2026-04-08",
+          "spec": "https://pay.google.com/gp/p/ucp/2026-04-08/",
+          "config_schema": "https://pay.google.com/gp/p/ucp/2026-04-08/schemas/config.json",
+          "instrument_schemas": [
+            "https://pay.google.com/gp/p/ucp/2026-04-08/schemas/card_payment_instrument.json"
+          ],
+          "config": {
+            "api_version": 2,
+            "api_version_minor": 0,
+            "merchant_info": {
+              "merchant_name": "Flower Shop",
+              "merchant_id": "TEST",
+              "merchant_origin": "localhost"
+            },
+            "allowed_payment_methods": [
+              {
+                "type": "CARD",
+                "parameters": {
+                  "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+                  "allowedCardNetworks": ["VISA", "MASTERCARD"]
+                },
+                "tokenization_specification": [
+                  {
+                    "type": "PAYMENT_GATEWAY",
+                    "parameters": [
+                      {
+                        "gateway": "example",
+                        "gatewayMerchantId": "exampleGatewayMerchantId"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "dev.mock.payment_handler": [
+        {
+          "id": "mock_payment_handler",
+          "name": "mock_payment_handler",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/schemas/mock_payment_handler/spec",
+          "config": {}
+        }
+      ]
+    },
+    "keys": [
       {
-        "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping/checkout",
-        "schema": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json",
-        "extends": null,
-        "config": null
-      },
-      {
-        "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping/discount",
-        "schema": "https://ucp.dev/2026-04-08/schemas/shopping/discount.json",
-        "extends": "dev.ucp.shopping.checkout",
-        "config": null
-      },
-      {
-        "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/shopping/fulfillment",
-        "schema": "https://ucp.dev/2026-04-08/schemas/shopping/fulfillment.json",
-        "extends": "dev.ucp.shopping.checkout",
-        "config": null
+        "kty": "EC",
+        "crv": "P-256",
+        "kid": "<runtime-generated>",
+        "x": "<runtime-generated>",
+        "y": "<runtime-generated>"
       }
     ]
   },
-  "payment": {
-    "handlers": [
-      {
-        "id": "shop_pay",
-        "name": "com.shopify.shop_pay",
-        "version": "2026-04-08",
-        "spec": "https://shopify.dev/ucp/handlers/shop_pay",
-        "config_schema": "https://shopify.dev/ucp/handlers/shop_pay/config.json",
-        "instrument_schemas": [
-          "https://shopify.dev/ucp/handlers/shop_pay/instrument.json"
-        ],
-        "config": {
-          "shop_id": "a1c4c1fc-6416-4103-afb3-65046e1c7787"
-        }
-      },
-      {
-        "id": "google_pay",
-        "name": "google.pay",
-        "version": "2026-04-08",
-        "spec": "https://example.com/spec",
-        "config_schema": "https://example.com/schema",
-        "instrument_schemas": [
-          "https://ucp.dev/2026-04-08/schemas/shopping/types/gpay_card_payment_instrument.json"
-        ],
-        "config": {
-          "api_version": 2,
-          "api_version_minor": 0,
-          "merchant_info": {
-            "merchant_name": "Flower Shop",
-            "merchant_id": "TEST",
-            "merchant_origin": "localhost"
-          },
-          "allowed_payment_methods": [
-            {
-              "type": "CARD",
-              "parameters": {
-                "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
-                "allowedCardNetworks": ["VISA", "MASTERCARD"]
-              },
-              "tokenization_specification": [
-                {
-                  "type": "PAYMENT_GATEWAY",
-                  "parameters": [
-                    {
-                      "gateway": "example",
-                      "gatewayMerchantId": "exampleGatewayMerchantId"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "id": "mock_payment_handler",
-        "name": "dev.ucp.mock_payment",
-        "version": "2026-04-08",
-        "spec": "https://ucp.dev/2026-04-08/specification/mock",
-        "config_schema": "https://ucp.dev/2026-04-08/schemas/mock.json",
-        "instrument_schemas": [
-          "https://ucp.dev/2026-04-08/schemas/shopping/types/card_payment_instrument.json"
-        ],
-        "config": {
-          "supported_tokens": ["success_token", "fail_token"]
-        }
-      }
-    ]
-  },
-  "keys": null
+  "signing_keys": [
+    {
+      "kty": "EC",
+      "crv": "P-256",
+      "kid": "<runtime-generated>",
+      "x": "<runtime-generated>",
+      "y": "<runtime-generated>"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
## Description

The Discovery section of `rest/python/server/README.md` labels its JSON block
as the response returned by `/.well-known/ucp`, but the example still uses the
old profile layout:

- `services.dev.ucp.shopping` is an object instead of a transport-entry array;
- `capabilities` is an array instead of a capability-name map;
- payment handlers are outside `ucp` under `payment.handlers`.

The route now serves `routes/discovery_profile.json`, with dynamic
`signing_keys` and `ucp.keys` added at request time. Its response uses the
current `ucp.services`, `ucp.capabilities`, and `ucp.payment_handlers` shapes.

**Fix:** update the documented response to match the live endpoint, using
explicit placeholders for runtime-generated shop and signing-key values.

## Category (Required)

- [ ] **Core Protocol**: Changes to the UCP core protocol. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: Changes to UCP capabilities. (Requires Maintainer approval)
- [x] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, or repository infrastructure changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency or maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Community health file changes. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `GET /.well-known/ucp` through the FastAPI test client returned 200 with
  `public, max-age=3600`; verified its services, capabilities, payment handlers,
  and signing-key container shapes.
- Parsed the updated README JSON and asserted the same stable shape, local
  endpoint, and runtime-generated-value placeholders.
- Full pre-commit and `git diff --check` pass.
