### PR TITLE
docs(a2a): use symbol references in ADK guide

### DIFF
--- a/a2a/docs/02-adk-agent.md
+++ b/a2a/docs/02-adk-agent.md
@@ -9,7 +9,7 @@
 ## Agent Configuration
 
 ```python
-# agent.py:437
+# agent.py: root_agent
 root_agent = Agent(
     name="shopper_agent",
     model="gemini-3-flash-preview",
@@ -125,7 +125,7 @@ With callbacks:
 Captures UCP data from tool results for later use:
 
 ```python
-# agent.py:379
+# agent.py: after_tool_modifier
 def after_tool_modifier(
     tool: BaseTool,
     args: dict[str, Any],
@@ -150,7 +150,7 @@ def after_tool_modifier(
 Transforms agent output to include structured data:
 
 ```python
-# agent.py:408
+# agent.py: modify_output_after_agent
 from google.genai import types
 
 def modify_output_after_agent(
@@ -239,7 +239,7 @@ class ADKAgentExecutor:
 
 ### Current System Instruction
 
-The agent uses a single instruction (`agent.py:441-454`):
+The agent uses a single instruction in the `root_agent` configuration:
 
 ```python
 instruction=(
@@ -303,7 +303,7 @@ ERROR HANDLING:
 | Gemini 3.0 Flash | Tool-heavy agents (this sample)      | Fastest, 99% tool accuracy           |
 | Gemini 2.0 Pro   | Complex reasoning, ambiguous queries | Slower, better nuanced understanding |
 
-To change the model, edit `agent.py:437`:
+To change the model, edit the `root_agent` configuration in `agent.py`:
 
 ```python
 root_agent = Agent(


### PR DESCRIPTION
## Description

`a2a/docs/02-adk-agent.md` points readers to several fixed `agent.py` line
numbers for the ADK agent hooks and configuration:

```markdown
# agent.py:437
# agent.py:379
# agent.py:408
The agent uses a single instruction (`agent.py:441-454`)
To change the model, edit `agent.py:437`
```

Those numbers have drifted from the current source: `after_tool_modifier` is at
line 366, `modify_output_after_agent` is at line 395, and `root_agent` starts at
line 424. The referenced symbols are still stable, so the guide can navigate by
symbol name instead of by brittle line numbers.

**Fix:** replace the stale line-number references with `root_agent`,
`after_tool_modifier`, and `modify_output_after_agent` symbol references.

## Category (Required)

- [ ] **Core Protocol**: Changes to the core protocol specification, schemas, or protocol documentation. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance, contribution processes, or project policies. (Requires Governance Council approval)
- [ ] **Capability**: New or modified capability specifications. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes, website updates, examples, or guides. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, build systems, tooling, or repository configuration. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates, refactoring, cleanup, or routine maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Issue templates, PR templates, code of conduct, or community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have performed a self-review of my changes.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

Validation:

```text
NO_STALE_AGENT_LINE_REFS
source symbols: after_tool_modifier, modify_output_after_agent, root_agent, instruction
npx prettier --check ../docs/02-adk-agent.md: passed
git diff --check: passed
uvx pre-commit run --all-files: passed
```
