### PR TITLE
docs(a2a): lower business agent Python prerequisite to 3.10

### DIFF
--- a/a2a/business_agent/README.md
+++ b/a2a/business_agent/README.md
@@ -20,7 +20,7 @@ Example agent implementing A2A Extension for UCP
 
 ### Pre-requisites:
 
-1. Python 3.13
+1. Python 3.10+
 2. UV
 3. Gemini API Key (The agent uses Gemini model to generate responses)
 


### PR DESCRIPTION
## Description

`a2a/business_agent/README.md` lists `Python 3.13` as a prerequisite, but the
sample's `pyproject.toml` declares `requires-python = ">=3.10"`, and running
the CLI under CPython 3.10 works:

```bash
uv run --python 3.10 business_agent --help
# exit 0, prints the CLI usage
```

The 3.13 requirement is a development convenience recorded in the sample's
`.python-version` file, not a compatibility promise for users; the README
drives the version new users install, so it should match the package metadata.

**Fix:** lower the documented prerequisite from `Python 3.13` to `Python 3.10+`
to match `requires-python = ">=3.10"`.

## Category (Required)

- [ ] **Core Protocol**: Protocol specification changes. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Governance or contribution process changes. (Requires Governance Council approval)
- [ ] **Capability**: Capability specification changes. (Requires Maintainer approval)
- [x] **Documentation**: Documentation updates. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, tooling, or release changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency, compatibility, or routine maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Repository-wide health files and configuration. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`.

## Screenshots / Logs (if applicable)

`uv run --python 3.10 business_agent --help`: exit 0, usage output  
`uvx pre-commit run --all-files`: passed  
`git diff --check`: passed
