### PR TITLE
docs(a2a): drop drifting line numbers from store method docs

### DIFF
--- a/a2a/docs/01-architecture.md
+++ b/a2a/docs/01-architecture.md
@@ -99,13 +99,13 @@ The diagram illustrates the separation between:
 
 ### Key Methods
 
-| Method              | Line | Called By                      | Purpose                               |
-| ------------------- | ---- | ------------------------------ | ------------------------------------- |
-| `search_products()` | 100  | `search_shopping_catalog` tool | Keyword search in catalog             |
-| `add_to_checkout()` | 186  | `add_to_checkout` tool         | Create/update checkout session        |
-| `get_checkout()`    | 244  | `get_checkout` tool            | Retrieve current checkout state       |
-| `start_payment()`   | 463  | `start_payment` tool           | Validate checkout for payment         |
-| `place_order()`     | 498  | `complete_checkout` tool       | Finalize order, generate confirmation |
+| Method              | Called By                      | Purpose                               |
+| ------------------- | ------------------------------ | ------------------------------------- |
+| `search_products()` | `search_shopping_catalog` tool | Keyword search in catalog             |
+| `add_to_checkout()` | `add_to_checkout` tool         | Create/update checkout session        |
+| `get_checkout()`    | `get_checkout` tool            | Retrieve current checkout state       |
+| `start_payment()`   | `start_payment` tool           | Validate checkout for payment         |
+| `place_order()`     | `complete_checkout` tool       | Finalize order, generate confirmation |
 
 ### Replacing with Real Backend
 

--- a/a2a/docs/04-commerce-flows.md
+++ b/a2a/docs/04-commerce-flows.md
@@ -163,7 +163,7 @@ def _recalculate_checkout(self, checkout: Checkout) -> None:
 ### Fulfillment Options
 
 ```python
-# store.py:525 - _get_fulfillment_options()
+# store.py - _get_fulfillment_options()
 [
     FulfillmentOptionResponse(
         id="standard",
@@ -192,7 +192,7 @@ def _recalculate_checkout(self, checkout: Checkout) -> None:
 
 ## OrderConfirmation
 
-Created in `place_order()` when checkout completes (store.py:498):
+Created in `place_order()` when checkout completes (`store.py`):
 
 ```python
 checkout.status = "completed"

--- a/a2a/docs/06-extending.md
+++ b/a2a/docs/06-extending.md
@@ -62,7 +62,7 @@ def _get_tax_rate(self, address: PostalAddress) -> float:
 
 ### Add Minimum Order
 
-**File**: `store.py` - `start_payment()` method (line 463)
+**File**: `store.py` - `start_payment()` method
 
 ```python
 def start_payment(self, checkout_id: str) -> Checkout | str:
@@ -78,7 +78,7 @@ def start_payment(self, checkout_id: str) -> Checkout | str:
 
 ### Custom Shipping Options
 
-**File**: `store.py` - `_get_fulfillment_options()` method (line 525)
+**File**: `store.py` - `_get_fulfillment_options()` method
 
 ```python
 def _get_fulfillment_options(self, address: PostalAddress) -> list:


### PR DESCRIPTION
## Description

Three A2A docs pin `store.py` methods to fixed source line numbers that have
drifted as `a2a/business_agent/src/business_agent/store.py` evolved:

| Doc | Reference | Documented | Actual line |
| --- | --- | ---: | ---: |
| `01-architecture.md` | `start_payment()` | 463 | 452 |
| `01-architecture.md` | `place_order()` | 498 | 484 |
| `04-commerce-flows.md` | `_get_fulfillment_options()` | 525 | 511 |
| `04-commerce-flows.md` | `place_order()` | 498 | 484 |
| `06-extending.md` | `start_payment()` | 463 | 452 |
| `06-extending.md` | `_get_fulfillment_options()` | 525 | 511 |

The `01-architecture.md` "Key Methods" table also lists a `Line` column whose
`add_to_checkout` (186 vs 183) and `get_checkout` (244 vs 241) values are
already wrong and will keep advancing. Line numbers are volatile navigation
state; the method names and file path already locate the implementation.

**Fix:** remove the drifting line markers while keeping the method names and
`store.py` file reference, so the docs stop navigating readers to the wrong
source lines.

## Category (Required)

- [ ] **Core Protocol**: Protocol specification changes. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Governance or contribution process changes. (Requires Governance Council approval)
- [ ] **Capability**: Capability specification changes. (Requires Maintainer approval)
- [x] **Documentation**: Documentation updates. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, tooling, or release changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency, compatibility, or routine maintenance changes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Repository-wide health files and configuration. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`.

## Screenshots / Logs (if applicable)

`rg -n '^    def ' store.py` confirms current definitions (452/484/511); no
`store.py:<line>` or `(line N)` references remain for these methods.  
`uvx pre-commit run --all-files`: passed  
`git diff --check`: passed
