### PR TITLE
test(rest/python): adapt checkout fixture to ucp-sdk 0.4.6

### DIFF
--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -81,7 +81,7 @@ from ucp_sdk.models.schemas.shopping.types import (
   line_item_create_request as line_item_create_req,
 )
 from ucp_sdk.models.schemas.shopping.types import (
-  shipping_destination as shipping_destination_req,
+  shipping_destination_create_request as shipping_destination_req,
 )
 
 FLAGS = flags.FLAGS
@@ -250,7 +250,7 @@ class IntegrationTest(absltest.TestCase):
     payment = payment_create_req.PaymentCreateRequest(instruments=[])
 
     # Hierarchical Fulfillment Construction
-    destination = shipping_destination_req.ShippingDestination(
+    destination = shipping_destination_req.ShippingDestinationCreateRequest(
       id="dest_1", address_country="US"
     )
     group = fulfillment_group_create_req.FulfillmentGroupCreateRequest(


### PR DESCRIPTION
# Description

## Problem

The shared checkout payload fixture in `rest/python/server/integration_test.py` builds a `FulfillmentMethodCreateRequest` with the response model `ShippingDestination`.

A fresh sync currently resolves `ucp-sdk 0.4.6`. Its generated `destinations` field validates operation-specific request models, so passing `ShippingDestination` raises a Pydantic `ValidationError` before any HTTP request is sent. This breaks the Python integration tests that reuse `_create_checkout_payload`.

## Change

Import and construct `ShippingDestinationCreateRequest` in the checkout-create fixture so the nested model matches `FulfillmentMethodCreateRequest.destinations`.

This is a test-fixture compatibility fix only. It does not change merchant-server runtime behavior, protocol schemas, or API responses.

## Category (Required)

- [ ] **Core Protocol**
- [ ] **Governance/Contributing**
- [ ] **Capability**
- [ ] **Documentation**
- [ ] **Infrastructure**
- [ ] **Maintenance**
- [ ] **SDK**
- [x] **Samples / Conformance**
- [ ] **UCP Schema**
- [ ] **Community Health (.github)**

## Related Issues

None.

## Verification

Focused reproduction with `ucp-sdk 0.4.6`:

```
baseline ShippingDestination: ValidationError
fixed ShippingDestinationCreateRequest: accepted
```

Full local checks:

```
pytest -q
245 passed, 3 warnings, 12 subtests passed

ruff check integration_test.py
ruff format --check integration_test.py
git diff --check
```

## Checklist

- [x] I followed the contributing guide and used a Conventional Commits title.
- [x] Documentation is not applicable because this only changes a test fixture.
- [x] Local linting and formatting checks pass.
- [x] Existing integration tests directly reproduce and verify the fix.
- [x] New and existing tests pass locally.
- [x] Schema changes and SDK model regeneration are not applicable.