### PR TITLE
fix(rest/python): bound ucp-sdk below 0.5 until the server targets v2026-08-25

### DIFF
--- a/rest/python/client/flower_shop/pyproject.toml
+++ b/rest/python/client/flower_shop/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "cryptography>=42",
     "pydantic>=2.12.0",
-    "ucp-sdk",
+    "ucp-sdk>=0.4.6,<0.5",
 ]
 
 [dependency-groups]

--- a/rest/python/server/integration_test.py
+++ b/rest/python/server/integration_test.py
@@ -81,7 +81,7 @@ from ucp_sdk.models.schemas.shopping.types import (
   line_item_create_request as line_item_create_req,
 )
 from ucp_sdk.models.schemas.shopping.types import (
-  shipping_destination as shipping_destination_req,
+  shipping_destination_create_request as shipping_destination_req,
 )
 
 FLAGS = flags.FLAGS
@@ -250,7 +250,7 @@ class IntegrationTest(absltest.TestCase):
     payment = payment_create_req.PaymentCreateRequest(instruments=[])
 
     # Hierarchical Fulfillment Construction
-    destination = shipping_destination_req.ShippingDestination(
+    destination = shipping_destination_req.ShippingDestinationCreateRequest(
       id="dest_1", address_country="US"
     )
     group = fulfillment_group_create_req.FulfillmentGroupCreateRequest(

--- a/rest/python/server/pyproject.toml
+++ b/rest/python/server/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "greenlet>=3.0.0",
     "fastapi-code-generator>=0.5.4",
     "click==8.1.7",
-    "ucp-sdk",
+    "ucp-sdk>=0.4.6,<0.5",
     "shortuuid",
     "httpx>=0.26.0",
     "cryptography>=42",


### PR DESCRIPTION
## What

One line: rest/python/server/pyproject.toml declares "ucp-sdk" with no bound; this change bounds it to ">=0.4.6,<0.5" so fresh resolutions stay on the 0.4.x line this server is generated against. The bound lifts when the server migrates to spec v2026-08-25.

## Why

The server implements UCP 2026-04-08. ucp-sdk 0.5.0, published 2026-08-27T16:10Z, regenerates the models for spec v2026-08-25 and relocates the payment schemas out of shopping/, so a fresh clone now fails at import time: ModuleNotFoundError for ucp_sdk.models.schemas.shopping.payment_create_request via generated_routes/ucp_routes.py, and test collection stops with 3 errors.

## Testing

Fresh clone at main (00333a80):
- Unbounded, uv sync resolves 0.5.0: import server fails with the ModuleNotFoundError above.
- With the bound, uv sync resolves 0.4.6: the server imports, all 245 tests collect, and simple_happy_path_client.py completes the full discovery through completion flow against a booted server.
- Pinned pre-commit on the changed file: all hooks pass.

Fixes #221.
